### PR TITLE
feat: ID mode and filesMetadata option (#27)

### DIFF
--- a/components/confluence-sync/CHANGELOG.md
+++ b/components/confluence-sync/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
+## [1.0.0] - 2025-01-22
+
+### Added
+
+* feat: Add "id" mode, which only allows to update pages by its Confluence page ID. It throws when there is a page without an ID or with an ancestor, or when rootPageId is provided.
+* feat: Do not allow "flat" mode when all pages have an id. "id" mode should be used instead.
+* feat: Validate sync modes at the very beginning. It throws when a non-existing mode is provided.
+
 ## [1.0.0-beta.1]
 
 ### Added

--- a/components/confluence-sync/package.json
+++ b/components/confluence-sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tid-xcut/confluence-sync",
   "description": "Creates/updates/deletes Confluence pages based on a list of objects containing the page contents. Supports nested pages and attachments upload",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "author": "Telefónica Innovación Digital",
   "repository": {

--- a/components/confluence-sync/src/ConfluenceSyncPages.types.ts
+++ b/components/confluence-sync/src/ConfluenceSyncPages.types.ts
@@ -12,6 +12,7 @@ import type {
 export enum SyncModes {
   TREE = "tree",
   FLAT = "flat",
+  ID = "id",
 }
 
 /** Type for dictionary values */

--- a/components/confluence-sync/src/errors/InvalidSyncModeException.ts
+++ b/components/confluence-sync/src/errors/InvalidSyncModeException.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { SyncModes } from "../ConfluenceSyncPages.types";
+
+export class InvalidSyncModeException extends Error {
+  constructor(syncMode: string, options?: ErrorOptions) {
+    super(
+      `Invalid sync mode "${syncMode}". Please use one of "${SyncModes.FLAT}", "${SyncModes.TREE}" or "${SyncModes.ID}"`,
+      options,
+    );
+  }
+}

--- a/components/confluence-sync/src/errors/PagesWithoutIdException.ts
+++ b/components/confluence-sync/src/errors/PagesWithoutIdException.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ConfluenceInputPage } from "../ConfluenceSyncPages.types";
+import { getPagesTitlesCommaSeparated } from "../support/Pages";
+
+export class PagesWithoutIdException extends Error {
+  constructor(pagesWithoutId?: ConfluenceInputPage[], options?: ErrorOptions) {
+    super(
+      `You are using ID mode and there are pages without id: ${getPagesTitlesCommaSeparated(
+        pagesWithoutId as ConfluenceInputPage[],
+      )}`,
+      options,
+    );
+  }
+}

--- a/components/confluence-sync/src/errors/RootPageForbiddenException.ts
+++ b/components/confluence-sync/src/errors/RootPageForbiddenException.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export class RootPageForbiddenException extends Error {
+  constructor(options?: ErrorOptions) {
+    super("rootPageId option is not allowed in ID mode", options);
+  }
+}

--- a/components/confluence-sync/src/errors/RootPageRequiredException.ts
+++ b/components/confluence-sync/src/errors/RootPageRequiredException.ts
@@ -1,26 +1,15 @@
 // SPDX-FileCopyrightText: 2024 Telefónica Innovación Digital and contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ConfluenceInputPage } from "../ConfluenceSyncPages.types";
 import { SyncModes } from "../ConfluenceSyncPages.types";
-import { getPagesTitlesCommaSeparated } from "../support/Pages";
 
 export class RootPageRequiredException extends Error {
-  constructor(
-    mode: SyncModes,
-    pagesWithoutId?: ConfluenceInputPage[],
-    options?: ErrorOptions,
-  ) {
+  constructor(mode: SyncModes, options?: ErrorOptions) {
     /* istanbul ignore else */
     if (mode === SyncModes.TREE) {
       super("rootPageId is required for TREE sync mode", options);
     } else if (mode === SyncModes.FLAT) {
-      super(
-        `rootPageId is required for FLAT sync mode when there are pages without id: ${getPagesTitlesCommaSeparated(
-          pagesWithoutId as ConfluenceInputPage[],
-        )}`,
-        options,
-      );
+      super("rootPageId is required for FLAT sync mode", options);
     } else {
       /* istanbul ignore next */
       super("Unknown sync mode", options);

--- a/components/confluence-sync/src/errors/ShouldUseIdModeException.ts
+++ b/components/confluence-sync/src/errors/ShouldUseIdModeException.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export class ShouldUseIdModeException extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}

--- a/components/confluence-sync/test/component/support/fixtures/Pages.ts
+++ b/components/confluence-sync/test/component/support/fixtures/Pages.ts
@@ -185,7 +185,6 @@ export const flatPages: ConfluenceInputPage[] = [
   {
     title: "foo-page-3-title",
     content: "foo-page-3-content",
-    id: "foo-page-3-id",
   },
 ];
 

--- a/components/markdown-confluence-sync/CHANGELOG.md
+++ b/components/markdown-confluence-sync/CHANGELOG.md
@@ -1,8 +1,3 @@
----
-sync_to_confluence: true
-title: "[Markdown Confluence Sync] [TypeScript] Releases"
----
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -15,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 #### Deprecated
 #### Removed
+
+## [1.0.0] - 2025-01-22
+
+### Added
+
+* feat: Add id mode. Upgrade confluence-sync to 1.0.0.
+* feat: Add filesMetadata option, enabling to defined the metadata of the files using the configuration file.
+
+### Changed
+
+* chore: Remove frontmatter properties from docs. Use filesMetadata instead to define the metadata of the files when syncing them to Confluence.
 
 ## [1.0.0-beta.4] - 2024-11-28
 

--- a/components/markdown-confluence-sync/README.md
+++ b/components/markdown-confluence-sync/README.md
@@ -1,12 +1,13 @@
----
-sync_to_confluence: true
-title: "[Markdown Confluence Sync] TypeScript"
-confluence_page_id: "337906335"
----
-
 # markdown-confluence-sync
 
-Creates/updates/deletes [Confluence](https://www.atlassian.com/es/software/confluence) pages based on markdown files in a directory. Supports Mermaid diagrams and per-page configuration using [frontmatter metadata](https://jekyllrb.com/docs/front-matter/). Works great with [Docusaurus](https://docusaurus.io/).
+Updates/creates [Confluence](https://www.atlassian.com/es/software/confluence) pages based on markdown files content.
+
+It is able to create/update/delete pages based on the markdown files structure in a directory, emulating the hierarchy in Confluence, keeping the content in sync.
+
+* Supports attaching images.
+* Supports Mermaid diagrams.
+* Supports per-page configuration using [frontmatter metadata](https://jekyllrb.com/docs/front-matter/).
+* Works great with [Docusaurus](https://docusaurus.io/).
 
 ## Table of Contents
 
@@ -34,6 +35,8 @@ Creates/updates/deletes [Confluence](https://www.atlassian.com/es/software/confl
   - [Arguments](#arguments)
   - [Environment variables](#environment-variables)
 - [Configuration per page](#configuration-per-page)
+  - [Frontmatter metadata](#frontmatter-metadata)
+  - [filesMetadata property](#filesmetadata-property)
 - [Automation notice](#automation-notice)
 - [Markdown conversion](#markdown-conversion)
   - [Supported features](#supported-features)
@@ -53,7 +56,7 @@ In order to be able to sync the markdown files with Confluence, you need to have
 * A [Confluence](https://www.atlassian.com/es/software/confluence) instance.
 * The id of the Confluence space where the pages will be created.
 * A personal access token to authenticate. You can create a personal access token following the instructions in the [Atlassian documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
-* A folder containing the markdown files to be synced with Confluence. It can be a Docusaurus project docs folder.
+* Markdown file or files to be synced with Confluence. It can be as complex as a Docusaurus project docs folder, or as simple as a single README.md file.
 
 ### Compatibility
 
@@ -65,9 +68,7 @@ In order to be able to sync the markdown files with Confluence, you need to have
 The library reads the markdown files in a given folder and create/delete/update the corresponding Confluence pages following the same hierarchical structure under a provided Confluence page depending on the [synchronization mode](#sync-modes) to use.
 
 > [!IMPORTANT]
-> Markdown documents to be synced __must have [frontmatter metadata](https://jekyllrb.com/docs/front-matter/)__ with at least next properties:
-> * `title` property, used to give a title to the page in Confluence.
-> * `sync_to_confluence` property set to `true`
+> You must provide the configuration for each file to be synced, or using the [configuration file](#configuration-file), or the [frontmatter metadata](#configuration-per-page), or a combination of both.
 
 ```markdown
 ---
@@ -80,16 +81,16 @@ sync_to_confluence: true
 Hello, world! I'm a markdown file to be synced with Confluence.
 ```
 
-The library has __two modes for syncing__:
+The library has __three modes for syncing__:
 * `tree` sync mode - Mirrors the hierarchical pages structure from given folder under a Confluence root page. Some files are used for [representing indices in the hierarchy](#index-files).
-* `flat` sync mode - Synchronize a list of markdown files matched by a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) as children page of a Confluence root page, without any hierarchy.
-  * As an extra in this mode, a Confluence id can be provided to each page using the frontmatter, and, in such case, the corresponding Confluence page will be updated. Read [per-page configuration](#configuration-per-page) for more information.
+* `id` sync mode - Synchronize a list of markdown files matched by a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) directly to specific Confluence pages using the Confluence id provided in the frontmatter metadata or in the configuration file.
+* `flat` sync mode - Synchronize a list of markdown files matched by a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) as children page of a Confluence root page, without any hierarchy. It is also possible to provide a Confluence id to some pages to update them directly, as in the `id` mode.
 
 Other features are:
 
 * The library adds a __notice message at the beginning of every pages content__ indicating that it has been generated automatically. Read [Automation notice](#automation-notice) for more information.
 * Converts Mermaid diagrams to images.
-* Supports __configuration per page using [frontmatter metadata](https://jekyllrb.com/docs/front-matter/).__ Some of the things you can configure are:
+* Supports __configuration per page using [frontmatter metadata](https://jekyllrb.com/docs/front-matter/) or the config file.__ Some of the things you can configure are:
   * Title of the page in Confluence.
   * Adding ancestors title to every page title.
 
@@ -122,7 +123,7 @@ The library provides an NPM binary named `markdown-confluence-sync`. To use it, 
 }
 ```
 
-All the markdown files to be synced must have frontmatter properties "title" and "sync_to_confluence" set to `true`. For example:
+All the markdown files to be synced must have frontmatter properties "title" and "sync_to_confluence" set to `true` (unless you are using the `filesMetadata` option in the configuration file). For example:
 
 ```markdown
 ---
@@ -157,7 +158,7 @@ npm run sync
 
 ## Sync modes
 
-The library has two modes for reading markdown files, `tree` and `flat`:
+The library has three modes for reading markdown files, `tree`, `flat` and `id`.
 
 ### Tree mode
 
@@ -236,18 +237,20 @@ repository/
 
 The `flat` mode syncs all markdown files matching a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) just under the root Confluence page. It does not create a nested hierarchy.
 
-It also supports defining a Confluence id in the frontmatter metadata of the markdown files. In this case, the library will always update the Confluence page with that id, even when it is not a children of the Confluence root page.
+It also supports defining a Confluence id to some pages. In this case, the library will always update the Confluence page with that id, even when it is not a children of the Confluence root page.
 
 To enable it, you have to set the `mode` property to `flat` in the configuration file, and provide a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) to filter the files to sync using the `filesPattern` property.
 
 > [!WARNING]
 > The `filePattern` option searches all files in the directory but filters the pattern results and ignores all files that do not have one of the following extensions: `md` or `mdx`.
 
-For example, with the provided configuration, `flat` synchronization mode will get all files starting with the "check" word, and having the extensions `md` or `mdx`:
+For example, with the next configuration, `flat` synchronization mode will get all files starting with the "check" word, and having the extensions `md` or `mdx`:
 
 ```js title="markdown-confluence-sync.config.js"
 module.exports = {
   docsDir: "docs",
+  mode: "flat",
+  filesPattern: "check*.{md,mdx}",
   confluence: {
     url: "https://my-confluence.es",
     personalAccessToken: "*******",
@@ -266,8 +269,9 @@ The namespace for the configuration of this library is `markdown-confluence-sync
 | Property | Type | Description | Default |
 | --- | --- | --- | --- |
 | `logLevel` | `string` | Log level. One of `silly`, `debug`, `info`, `warn`, `error`, `silent` | `info` |
-| `mode` | `string` | Mode to read the pages to send to Confluence. One of `tree`, `flat`.  | `tree` |
-| `filesPattern` | `string` | Pattern to read the pages to send to Confluence. This option is mandatory when used `flat` sync mode.  |  |
+| `mode` | `string` | Mode to read the pages to send to Confluence. One of `tree`, `flat` or `id`.  | `tree` |
+| `filesPattern` | `string` | Pattern to read the pages to send to Confluence. This option is mandatory when using `flat` or `id` sync modes.  |  |
+| `filesMetadata` | `array` | Array of objects with the metadata of the files to sync. Each object must have the `path` property with the path of the file. For the rest of properties read the [Configuration per page](#configuration-per-page) section |  |
 | `docsDir` | `string` | Path to the docs directory. | `./docs` |
 | `confluence.url` | `string` | URL of the Confluence instance. | |
 | `confluence.personalAccessToken` | `string` | Personal access token to authenticate against the Confluence instance. | |
@@ -330,16 +334,61 @@ MARKDOWN_CONFLUENCE_SYNC_DOCS_DIR=./docs MARKDOWN_CONFLUENCE_SYNC_LOG=debug npx 
 
 ## Configuration per page
 
-It is possible to set some properties for each page using the frontmatter metadata in the markdown files. The properties that can be set are:
+It is possible to set some properties for each page using the frontmatter metadata in the markdown files or in the `filesMetadata` property in the configuration file. You can use one method or another, or a combination of both. __When using both methods, the properties set in the `filesMetadata` property will overwrite the ones set in the frontmatter metadata.__
 
-* `confluence_id` - Confluence id of the page. If set, the library will always update the Confluence page with that id, even when it is not a children of the Confluence root page. __It only can be set in `flat` sync mode.__
+### Frontmatter metadata
+
+* `confluence_id` - Confluence id of the page. If set, the library will always update the Confluence page with that id, even when it is not a children of the Confluence root page. __It only can be set in `flat` or `id` sync modes.__
 * `confluence_title` - Title of the page in Confluence. It will force the title of the page in Confluence to be the value of this property, ignoring the `title` property. Use it if you need to use the `title` property for other purposes (such as in Docusaurus pages), and you don't want to use the same value in Confluence.
-* `confluence_short_name` - Adding ancestors title to its children's title may produce an unnecessarily long titles. To avoid this, you can use this property to replace the title of a parent page in its children's title. It should be used only in **index files** for categories.
+* `confluence_short_name` - Adding ancestors title to its children's title may produce long titles. To avoid this, you can use this property to replace the title of a parent page in its children's title. It should be used only in **index files** for categories.
   For example, if the child's title is "`Page`" and the parent, with the title "`Parent Category`," has the property `confluence_short_name` set to "`Parent`," it will appear in Confluence as follows:
   ```diff
   - [Parent Category] Page
   + [Parent] Page
   ```
+* `sync_to_confluence` - Boolean to indicate if the file should be synced with Confluence. If set to `false`, the file will be ignored.
+
+```markdown
+---
+confluence_id: "123456789"
+confluence_title: "Confluence title"
+confluence_short_name: "Short name"
+sync_to_confluence: true
+---
+```
+
+### filesMetadata property
+
+The `filesMetadata` property in the configuration file allows you to set the metadata of the files to sync without having to modify the file itself to add the frontmatter metadata. So, it is less intrusive.
+
+It must be an array of objects, and each one must have the `path` property with the path of the file. The rest of the properties are the same as the ones that can be set in the frontmatter metadata, but with next naming convention:
+
+* `path` - Path of the file to assign the metadata to.
+* `id` - Confluence id of the page. If set, the library will always update the Confluence page with that id, even when it is not a children of the Confluence root page. __It only can be set in `flat` or `id` sync modes.__
+* `title` - Title of the page in Confluence. It will force the title of the page in Confluence to be the value of this property.
+* `shortName` - Adding ancestors title to its children's title may produce long titles. To avoid this, you can use this property to replace the title of a parent page in its children's title. It should be used only in **index files** for categories.
+* `sync` - Boolean to indicate if the file should be synced with Confluence. If set to `false`, the file will be ignored.
+
+```js
+/** @type {import('@tid-xcut/markdown-confluence-sync').Configuration} */
+module.exports = {
+  docsDir: "./docs",
+  filesMetadata: [
+    {
+      path: "./docs/page-a.md",
+      id: "123456789",
+      title: "My Awesome Page",
+      shortName: "MAwP",
+      sync: true,
+    },
+  ],
+  confluence: {
+    url: "https://my.confluence.es",
+    personalAccessToken: "*******",
+    spaceKey: "MY-SPACE",
+  },
+};
+```
 
 ## Automation notice
 

--- a/components/markdown-confluence-sync/markdown-confluence-sync.config.cjs
+++ b/components/markdown-confluence-sync/markdown-confluence-sync.config.cjs
@@ -15,6 +15,19 @@ module.exports = {
   mode: "flat",
   docsDir: ".",
   filesPattern: "*(README.md|CHANGELOG.md)",
+  filesMetadata: [
+    {
+      path: "README.md",
+      title: "[Markdown Confluence Sync] TypeScript",
+      id: "337906335",
+      sync: true,
+    },
+    {
+      path: "CHANGELOG.md",
+      title: "[Markdown Confluence Sync] [TypeScript] Releases",
+      sync: true,
+    },
+  ],
   confluence: {
     url: process.env.CONFLUENCE_URL,
     personalAccessToken: process.env.CONFLUENCE_PAT,

--- a/components/markdown-confluence-sync/package.json
+++ b/components/markdown-confluence-sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tid-xcut/markdown-confluence-sync",
   "description": "Creates/updates/deletes Confluence pages based on markdown files in a directory. Supports Mermaid diagrams and per-page configuration using frontmatter metadata. Works great with Docusaurus",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "author": "Telefónica Innovación Digital",
   "repository": {

--- a/components/markdown-confluence-sync/src/lib/MarkdownConfluenceSync.ts
+++ b/components/markdown-confluence-sync/src/lib/MarkdownConfluenceSync.ts
@@ -28,6 +28,8 @@ import type {
   FilesPatternOptionDefinition,
   ModeOption,
   FilesPatternOption,
+  FilesMetadataOptionDefinition,
+  FilesMetadataOption,
 } from "./MarkdownConfluenceSync.types.js";
 
 const MODULE_NAME = "markdown-confluence-sync";
@@ -57,6 +59,11 @@ const filesPatternOption: FilesPatternOptionDefinition = {
   type: "string",
 };
 
+const filesMetadataOption: FilesMetadataOptionDefinition = {
+  name: "filesMetadata",
+  type: "array",
+};
+
 export const MarkdownConfluenceSync: MarkdownConfluenceSyncConstructor = class MarkdownConfluenceSync
   implements MarkdownConfluenceSyncInterface
 {
@@ -69,6 +76,7 @@ export const MarkdownConfluenceSync: MarkdownConfluenceSyncConstructor = class M
   private _logLevelOption: LogLevelOption;
   private _modeOption: ModeOption;
   private _filesPatternOption: FilesPatternOption;
+  private _filesMetadataOption: FilesMetadataOption;
   private _cwd: string;
 
   constructor(config: Configuration) {
@@ -92,6 +100,10 @@ export const MarkdownConfluenceSync: MarkdownConfluenceSyncConstructor = class M
       filesPatternOption,
     ) as FilesPatternOption;
 
+    this._filesMetadataOption = this._configuration.addOption(
+      filesMetadataOption,
+    ) as FilesMetadataOption;
+
     const markdownLogger = this._logger.namespace(MARKDOWN_NAMESPACE);
 
     const confluenceConfig =
@@ -103,6 +115,7 @@ export const MarkdownConfluenceSync: MarkdownConfluenceSyncConstructor = class M
       logger: markdownLogger,
       mode: this._modeOption,
       filesPattern: this._filesPatternOption,
+      filesMetadata: this._filesMetadataOption,
       cwd: this._cwd,
     });
     this._confluenceSync = new ConfluenceSync({

--- a/components/markdown-confluence-sync/src/lib/MarkdownConfluenceSync.types.ts
+++ b/components/markdown-confluence-sync/src/lib/MarkdownConfluenceSync.types.ts
@@ -10,6 +10,21 @@ import type { SyncModes } from "@tid-xcut/confluence-sync";
 
 export type FilesPattern = string | string[];
 
+export interface FileMetadata {
+  /** Path to the file */
+  path: string;
+  /** Confluence page id */
+  id?: string;
+  /** Confluence page title */
+  title?: string;
+  /** Short name of the page to be used in the names of the child pages, when assigning namespacing */
+  shortName?: string;
+  /** Whether to sync or not the page */
+  sync?: boolean;
+}
+
+export type FilesMetadata = FileMetadata[];
+
 declare global {
   //eslint-disable-next-line @typescript-eslint/no-namespace
   namespace MarkdownConfluenceSync {
@@ -30,11 +45,14 @@ declare global {
       /** Mode to structure pages */
       mode?: SyncModes;
       /**
-       * Pattern to search files when flat mode is active
+       * Pattern to search files when flat or id mode are active
        * @see {@link https://github.com/isaacs/node-glob#globpattern-string--string-options-globoptions--promisestring--path | Node Glob Pattern}
        * @see {@link https://github.com/isaacs/node-glob#glob-primer}
        * */
       filesPattern?: FilesPattern;
+
+      /** Metadata for specific files */
+      filesMetadata?: FilesMetadata;
     }
   }
 }
@@ -62,6 +80,10 @@ export type ModeOption = OptionInterfaceOfType<SyncModes, { hasDefault: true }>;
 export type FilesPatternOptionDefinition = OptionDefinition<FilesPattern>;
 
 export type FilesPatternOption = OptionInterfaceOfType<FilesPattern>;
+
+export type FilesMetadataOptionDefinition = OptionDefinition<FilesMetadata>;
+
+export type FilesMetadataOption = OptionInterfaceOfType<FilesMetadata>;
 
 /** Creates a MarkdownConfluenceSync interface */
 export interface MarkdownConfluenceSyncConstructor {

--- a/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusFlatPages.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusFlatPages.types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { FilesPattern } from "../MarkdownConfluenceSync.types";
+import { SyncModes } from "@tid-xcut/confluence-sync";
 
 import type {
   MarkdownDocumentsInterface,
@@ -14,6 +15,8 @@ export interface MarkdownFlatDocumentsOptions
   filesPattern?: FilesPattern;
   /** Working directory */
   cwd: string;
+  /** Mode */
+  mode: SyncModes.FLAT | SyncModes.ID;
 }
 
 /** Creates a MarkdownFlatDocuments interface */

--- a/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPages.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPages.ts
@@ -7,6 +7,8 @@ import type { ConfigInterface } from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type {
+  FilesMetadata,
+  FilesMetadataOption,
   FilesPattern,
   FilesPatternOption,
   ModeOption,
@@ -41,6 +43,7 @@ export const MarkdownDocuments: MarkdownDocumentsConstructor = class MarkdownDoc
   private _logger: LoggerInterface;
   private _config: ConfigInterface;
   private _filesPattern?: FilesPatternOption;
+  private _filesMetadata?: FilesMetadataOption;
   private _cwd: string;
 
   constructor({
@@ -48,12 +51,14 @@ export const MarkdownDocuments: MarkdownDocumentsConstructor = class MarkdownDoc
     logger,
     mode,
     filesPattern,
+    filesMetadata,
     cwd,
   }: MarkdownDocumentsOptions) {
     this._docsDirOption = config.addOption(docsDirOption);
     this._cwd = cwd;
     this._modeOption = mode;
     this._filesPattern = filesPattern;
+    this._filesMetadata = filesMetadata;
     this._config = config;
     this._logger = logger;
   }
@@ -68,12 +73,21 @@ export const MarkdownDocuments: MarkdownDocumentsConstructor = class MarkdownDoc
     this._logger.debug(`mode option is ${this._modeOption.value}`);
     if (!this._initialized) {
       const path = resolve(this._cwd, this._docsDirOption.value);
+
+      const filesMetadata: FilesMetadata = (
+        this._filesMetadata?.value || []
+      ).map((metadata) => ({
+        ...metadata,
+        path: resolve(this._cwd, metadata.path),
+      }));
+
       this._path = path;
       this._pages = MarkdownDocumentsFactory.fromMode(this._modeOption.value, {
         config: this._config,
         logger: this._logger,
         path: this._path,
         filesPattern: this._filesPattern?.value as FilesPattern,
+        filesMetadata,
         cwd: this._cwd,
       });
       this._initialized = true;

--- a/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPages.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPages.types.ts
@@ -9,7 +9,9 @@ import type {
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type {
+  FilesMetadataOption,
   FilesPatternOption,
+  FilesMetadata,
   ModeOption,
 } from "../MarkdownConfluenceSync.types.js";
 
@@ -46,6 +48,8 @@ export interface MarkdownDocumentsOptions {
   mode: ModeOption;
   /** Pattern to search files when flat mode is active */
   filesPattern?: FilesPatternOption;
+  /** Metadata for specific files */
+  filesMetadata?: FilesMetadataOption;
   /** Working directory */
   cwd: string;
 }
@@ -84,6 +88,8 @@ export interface MarkdownDocumentsInterface {
 }
 
 export interface MarkdownDocumentsModeOptions {
+  /** Metadata for specific files */
+  filesMetadata?: FilesMetadata;
   /** Configuration interface */
   config: ConfigInterface;
   /** Logger */

--- a/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPagesFactory.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPagesFactory.ts
@@ -4,14 +4,12 @@
 import { SyncModes } from "@tid-xcut/confluence-sync";
 
 import { MarkdownFlatDocuments } from "./DocusaurusFlatPages.js";
-import type { MarkdownFlatDocumentsOptions } from "./DocusaurusFlatPages.types.js";
 import type { MarkdownDocumentsInterface } from "./DocusaurusPages.types.js";
 import type {
   MarkdownDocumentsFactoryInterface,
   MarkdownDocumentsFactoryOptions,
 } from "./DocusaurusPagesFactory.types.js";
 import { DocusaurusTreePages } from "./DocusaurusTreePages.js";
-import type { DocusaurusTreePagesOptions } from "./DocusaurusTreePages.types.js";
 
 export const MarkdownDocumentsFactory: MarkdownDocumentsFactoryInterface = class MarkdownDocumentsFactory {
   public static fromMode(
@@ -19,12 +17,19 @@ export const MarkdownDocumentsFactory: MarkdownDocumentsFactoryInterface = class
     options: MarkdownDocumentsFactoryOptions,
   ): MarkdownDocumentsInterface {
     if (!this._isValidMode(mode)) {
-      throw new Error(`"mode" option must be one of "tree" or "flat"`);
+      throw new Error(`"mode" option must be one of "tree", "flat" or "id"`);
     }
-    if (this._isFlatMode(mode)) {
-      return new MarkdownFlatDocuments(options as MarkdownFlatDocumentsOptions);
+    if (this._isFlatMode(mode) || this._isIdMode(mode)) {
+      return new MarkdownFlatDocuments({
+        ...options,
+        mode: mode as SyncModes.FLAT | SyncModes.ID,
+      });
     }
-    return new DocusaurusTreePages(options as DocusaurusTreePagesOptions);
+    return new DocusaurusTreePages(options);
+  }
+
+  private static _isIdMode(mode: string): boolean {
+    return mode === SyncModes.ID;
   }
 
   private static _isFlatMode(mode: string): boolean {
@@ -32,6 +37,10 @@ export const MarkdownDocumentsFactory: MarkdownDocumentsFactoryInterface = class
   }
 
   private static _isValidMode(mode: string): boolean {
-    return mode === SyncModes.FLAT || mode === SyncModes.TREE;
+    return (
+      mode === SyncModes.FLAT ||
+      mode === SyncModes.TREE ||
+      mode === SyncModes.ID
+    );
   }
 };

--- a/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPagesFactory.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusPagesFactory.types.ts
@@ -5,7 +5,7 @@ import type { ConfigInterface } from "@mocks-server/config";
 import type { LoggerInterface } from "@mocks-server/logger";
 import type { SyncModes } from "@tid-xcut/confluence-sync";
 
-import type { FilesPattern } from "..";
+import type { FilesMetadata, FilesPattern } from "..";
 
 import type { MarkdownDocumentsInterface } from "./DocusaurusPages.types";
 
@@ -18,6 +18,8 @@ export interface MarkdownDocumentsFactoryOptions {
   path: string;
   /** Pattern to search files when flat mode is active */
   filesPattern?: FilesPattern;
+  /** Metadata for specific files */
+  filesMetadata?: FilesMetadata;
   /** Working directory */
   cwd: string;
 }

--- a/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusTreePages.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/DocusaurusTreePages.ts
@@ -16,6 +16,7 @@ import type {
 import { DocusaurusDocTree } from "./tree/DocusaurusDocTree.js";
 import type { DocusaurusDocTreeInterface } from "./tree/DocusaurusDocTree.types.js";
 import { buildIndexFileRegExp, getIndexFileFromPaths } from "./util/files.js";
+import { FilesMetadata } from "../MarkdownConfluenceSync.types.js";
 
 export const DocusaurusTreePages: DocusaurusTreePagesConstructor = class DocusaurusTreePages
   implements MarkdownDocumentsInterface
@@ -23,12 +24,15 @@ export const DocusaurusTreePages: DocusaurusTreePagesConstructor = class Docusau
   private _path: string;
   private _tree: DocusaurusDocTreeInterface;
   private _logger: LoggerInterface;
+  private _filesMetadata?: FilesMetadata;
 
-  constructor({ logger, path }: DocusaurusTreePagesOptions) {
+  constructor({ logger, path, filesMetadata }: DocusaurusTreePagesOptions) {
     this._path = path as string;
     this._logger = logger;
+    this._filesMetadata = filesMetadata;
     this._tree = new DocusaurusDocTree(this._path, {
       logger: this._logger.namespace("doc-tree"),
+      filesMetadata: this._filesMetadata,
     });
   }
 

--- a/components/markdown-confluence-sync/src/lib/docusaurus/pages/DocusaurusDocPage.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/pages/DocusaurusDocPage.types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { LoggerInterface } from "@mocks-server/logger";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types";
 
 /** Docusaurus file metadata */
 export interface DocusaurusDocPageMeta {
@@ -44,6 +45,8 @@ export interface DocusaurusDocPageInterface {
 export interface DocusaurusDocPageOptions {
   /** Logger */
   logger?: LoggerInterface;
+  /** Files metadata */
+  filesMetadata?: FilesMetadata;
 }
 
 /** Creates DocusaurusDocPage interface */

--- a/components/markdown-confluence-sync/src/lib/docusaurus/pages/DocusaurusDocPageFactory.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/pages/DocusaurusDocPageFactory.types.ts
@@ -4,10 +4,13 @@
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { DocusaurusDocPageInterface } from "./DocusaurusDocPage.types";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types";
 
 export interface DocusaurusDocPageFactoryFromPathOptions {
   /** Logger */
   logger?: LoggerInterface;
+  /** Files metadata */
+  filesMetadata?: FilesMetadata;
 }
 
 /**

--- a/components/markdown-confluence-sync/src/lib/docusaurus/pages/errors/TitleRequiredException.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/pages/errors/TitleRequiredException.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export class TitleRequiredException extends Error {
+  constructor(path: string, options?: ErrorOptions) {
+    super(
+      `Title is required: ${path}. Please provide it using frontmatter or filesMetadata option`,
+      options,
+    );
+  }
+}

--- a/components/markdown-confluence-sync/src/lib/docusaurus/pages/support/remark/remark-validate-frontmatter.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/pages/support/remark/remark-validate-frontmatter.ts
@@ -19,6 +19,10 @@ const remarkValidateFrontmatter: UnifiedPlugin<
 > = function remarkRemoveAdmonitions(schema) {
   return function (_tree, file) {
     try {
+      if (!file.data.frontmatter) {
+        file.data.frontmatter = {};
+        return;
+      }
       file.data.frontmatter = schema.parse(file.data.frontmatter);
     } catch (e) {
       if (e instanceof ZodError) {

--- a/components/markdown-confluence-sync/src/lib/docusaurus/pages/support/validators/FrontMatterValidator.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/pages/support/validators/FrontMatterValidator.ts
@@ -9,7 +9,7 @@ import z from "zod";
  * @see {@link https://docusaurus.io/docs/create-doc#doc-front-matter | Doc front matter}
  */
 export const FrontMatterValidator = z.object({
-  title: z.string().nonempty(),
+  title: z.string().nonempty().optional(),
   sync_to_confluence: z.boolean().optional().default(false),
   confluence_short_name: z.string().nonempty().optional(),
   confluence_title: z.string().nonempty().optional(),

--- a/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocItemFactory.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocItemFactory.types.ts
@@ -4,10 +4,13 @@
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { DocusaurusDocTreeItem } from "./DocusaurusDocTree.types.js";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types.js";
 
 export interface DocusaurusDocItemFactoryFromPathOptions {
   /** Logger */
   logger?: LoggerInterface;
+  /** Files metadata */
+  filesMetadata?: FilesMetadata;
 }
 
 /**

--- a/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTree.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTree.ts
@@ -14,12 +14,14 @@ import type {
   DocusaurusDocTreeItem,
   DocusaurusDocTreeOptions,
 } from "./DocusaurusDocTree.types.js";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types.js";
 
 export const DocusaurusDocTree: DocusaurusDocTreeConstructor = class DocusaurusDocTree
   implements DocusaurusDocTreeInterface
 {
   private _path: string;
   private _logger?: LoggerInterface;
+  private _filesMetadata?: FilesMetadata;
 
   constructor(path: string, options?: DocusaurusDocTreeOptions) {
     if (!existsSync(path)) {
@@ -27,6 +29,7 @@ export const DocusaurusDocTree: DocusaurusDocTreeConstructor = class DocusaurusD
     }
     this._path = path;
     this._logger = options?.logger;
+    this._filesMetadata = options?.filesMetadata;
   }
 
   public async flatten(): Promise<DocusaurusDocTreeItem[]> {
@@ -44,6 +47,7 @@ export const DocusaurusDocTree: DocusaurusDocTreeConstructor = class DocusaurusD
     const roots = rootDirs.map((path) =>
       DocusaurusDocItemFactory.fromPath(path, {
         logger: this._logger?.namespace(path.replace(this._path, "")),
+        filesMetadata: this._filesMetadata,
       }),
     );
     const rootsPages = await Promise.all(roots.map((root) => root.visit()));

--- a/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTree.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTree.types.ts
@@ -7,10 +7,13 @@ import type {
   DocusaurusDocPageInterface,
   DocusaurusDocPageMeta,
 } from "../pages/DocusaurusDocPage.types";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types";
 
 export interface DocusaurusDocTreeOptions {
   /** Logger */
   logger?: LoggerInterface;
+  /** Files metadata */
+  filesMetadata?: FilesMetadata;
 }
 
 /** Creates a DocusaurusDocTree interface */

--- a/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTreeCategory.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTreeCategory.ts
@@ -26,6 +26,7 @@ import type {
 import type { DocusaurusDocTreePageInterface } from "./DocusaurusDocTreePage.types.js";
 import { DocusaurusDocTreePageFactory } from "./DocusaurusDocTreePageFactory.js";
 import { CategoryItemMetadataValidator } from "./support/validators/CategoryItemMetadata.js";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types.js";
 
 export const DocusaurusDocTreeCategory: DocusaurusDocTreeCategoryConstructor = class DocusaurusDocTreeCategory
   implements DocusaurusDocTreeCategoryInterface
@@ -34,6 +35,7 @@ export const DocusaurusDocTreeCategory: DocusaurusDocTreeCategoryConstructor = c
   private _index: DocusaurusDocTreePageInterface | undefined;
   private _meta: DocusaurusDocTreeCategoryMeta | undefined;
   private _logger: LoggerInterface | undefined;
+  private _filesMetadata: FilesMetadata | undefined;
 
   constructor(path: string, options?: DocusaurusDocTreeCategoryOptions) {
     if (!existsSync(path)) {
@@ -57,6 +59,7 @@ export const DocusaurusDocTreeCategory: DocusaurusDocTreeCategoryConstructor = c
     this._path = path;
     this._meta = DocusaurusDocTreeCategory._processCategoryItemMetadata(path);
     this._logger = options?.logger;
+    this._filesMetadata = options?.filesMetadata;
   }
 
   public get isCategory(): boolean {
@@ -135,6 +138,7 @@ export const DocusaurusDocTreeCategory: DocusaurusDocTreeCategoryConstructor = c
       childrenPaths.map((path) =>
         DocusaurusDocItemFactory.fromPath(path, {
           logger: this._logger?.namespace(path.replace(this._path, "")),
+          filesMetadata: this._filesMetadata,
         }),
       ),
     );

--- a/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTreeCategory.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTreeCategory.types.ts
@@ -4,10 +4,13 @@
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { DocusaurusDocTreeItem } from "./DocusaurusDocTree.types.js";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types.js";
 
 export interface DocusaurusDocTreeCategoryOptions {
   /** Logger */
   logger?: LoggerInterface;
+  /** Files Metadata */
+  filesMetadata?: FilesMetadata;
 }
 
 /** Creates DocusaurusDocTreeCategory interface */

--- a/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTreePage.types.ts
+++ b/components/markdown-confluence-sync/src/lib/docusaurus/tree/DocusaurusDocTreePage.types.ts
@@ -4,10 +4,13 @@
 import type { LoggerInterface } from "@mocks-server/logger";
 
 import type { DocusaurusDocTreeItem } from "./DocusaurusDocTree.types.js";
+import { FilesMetadata } from "../../MarkdownConfluenceSync.types.js";
 
 export interface DocusaurusDocTreePageOptions {
   /** Logger */
   logger?: LoggerInterface;
+  /** Files metadata */
+  filesMetadata?: FilesMetadata;
 }
 
 /** Creates DocusaurusDocTreePage interface */

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child1/grandChild1.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child1/grandChild1.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild1 title
+
+This is the grandChild1 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child1/grandChild2.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child1/grandChild2.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild2 title
+
+This is the grandChild2 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child1/index.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child1/index.md
@@ -1,0 +1,3 @@
+# Here goes the child1 title
+
+This is the child1 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child2/grandChild3.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child2/grandChild3.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild3 title
+
+This is the grandChild3 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child2/grandChild4.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child2/grandChild4.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild4 title
+
+This is the grandChild4 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child2/index.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child2/index.md
@@ -1,0 +1,3 @@
+# Here goes the child2 title
+
+This is the child2 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child3/_category_.yml
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child3/_category_.yml
@@ -1,0 +1,2 @@
+---
+label: foo-child3-title

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child3/grandChild5.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child3/grandChild5.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild5 title
+
+This is the grandChild5 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child4/grandChild6.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child4/grandChild6.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild6 title
+
+This is the grandChild6 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child4/grandChild7.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child4/grandChild7.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild7 title
+
+This is the grandChild7 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child4/index.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child4/index.md
@@ -1,0 +1,3 @@
+# Here goes the child4 title
+
+This is the child4 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child5/_category_.yml
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child5/_category_.yml
@@ -1,0 +1,2 @@
+---
+label: foo-child5-title

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child5/grandChild8.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child5/grandChild8.md
@@ -1,0 +1,3 @@
+# Here goes the grandChild8 title
+
+This is the grandChild8 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child5/index.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child5/index.md
@@ -1,0 +1,3 @@
+# Here goes the child5 title
+
+This is the child5 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/_category_.yml
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/_category_.yml
@@ -1,0 +1,2 @@
+---
+label: foo-child6-title

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild10/_category_.yml
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild10/_category_.yml
@@ -1,0 +1,2 @@
+---
+label: foo-grandChild10-title

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild10/greatGrandChild2.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild10/greatGrandChild2.md
@@ -1,0 +1,3 @@
+# Here goes the greatGrandChild2 title
+
+This is the greatGrandChild2 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild9/_category_.yml
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild9/_category_.yml
@@ -1,0 +1,2 @@
+---
+label: foo-grandChild9-title

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild9/greatGrandChild1.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/child6/grandChild9/greatGrandChild1.md
@@ -1,0 +1,3 @@
+# Here goes the greatGrandChild1 title
+
+This is the greatGrandChild1 content

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/index.md
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/docs/parent/index.md
@@ -1,0 +1,42 @@
+# Title
+
+:::note
+⭐ this is an admonition
+:::
+
+
+## External Link
+
+This is a link:
+
+[External link](https://httpbin.org)
+
+## Internal Link
+
+This is a link:
+
+[Internal link](./child1/index.md)
+
+## Mdx Code Block
+
+This is a mdx code block:
+```mdx-code-block
+    <h1>Mdx code block test</h1>
+```
+
+## Details
+<!-- eslint-disable-next-line markdown/no-html -->
+<details><summary>Details</summary>
+```markdown
+    :::caution Status
+    Proposed
+    :::
+```
+</details>
+
+## Footnotes
+
+This is a paragraph with a footnote[^1].
+
+[^1]: This is a footnote.
+

--- a/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/markdown-confluence-sync.config.cjs
+++ b/components/markdown-confluence-sync/test/component/fixtures/mock-server-empty-root-files-metadata/markdown-confluence-sync.config.cjs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: MIT
+
+module.exports = {
+  logLevel: "info",
+  filesMetadata: [
+    {
+      path: "docs/parent/index.md",
+      id: "foo-parent",
+      title: "foo-parent-title",
+      sync: true
+    },
+    {
+      path: "docs/parent/child1/grandChild1.md",
+      id: "foo-grandChild1",
+      title: "foo-grandChild1-title",
+      sync: true
+    },
+    {
+      path: "docs/parent/child1/grandChild2.md",
+      id: "foo-grandChild2",
+      title: "foo-grandChild2-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child1/index.md",
+      id: "foo-child1",
+      title: "foo-child1-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child2/grandChild3.md",
+      id: "foo-grandChild3",
+      title: "foo-grandChild3-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child2/grandChild4.md",
+      id: "foo-grandChild4",
+      title: "foo-grandChild4-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child2/index.md",
+      id: "foo-child2",
+      title: "foo-child2-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child3/grandChild5.md",
+      id: "foo-grandChild5",
+      title: "foo-grandChild5-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child4/grandChild6.md",
+      id: "foo-grandChild6",
+      title: "foo-grandChild6-title",
+      shortName: "grandchild6",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child4/grandChild7.md",
+      id: "foo-grandChild7",
+      title: "foo-grandChild7-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child4/index.md",
+      id: "foo-child4",
+      title: "foo-child4-title",
+      shortName: "child4",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child5/grandChild8.md",
+      id: "foo-grandChild8",
+      title: "foo-grandChild8-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child5/index.md",
+      id: "foo-child5",
+      title: "foo-child5-title",
+      shortName: "child5",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child6/grandChild9/greatGrandChild1.md",
+      id: "foo-greatGrandChild1",
+      title: "foo-greatGrandChild-title",
+      sync: true,
+    },
+    {
+      path: "docs/parent/child6/grandChild10/greatGrandChild2.md",
+      id: "foo-greatGrandChild2",
+      title: "foo-greatGrandChild-title",
+      sync: true,
+    },
+  ],
+  confluence: {
+    url: "http://127.0.0.1:3100",
+    personalAccessToken: "foo-token",
+    spaceKey: "foo-space-id",
+    rootPageId: "foo-root-id",
+  },
+};

--- a/components/markdown-confluence-sync/test/component/specs/config.spec.ts
+++ b/components/markdown-confluence-sync/test/component/specs/config.spec.ts
@@ -110,7 +110,7 @@ describe("configuration", () => {
       expect(exitCode).toBe(1);
       expect(cleanLogs(logs)).toEqual(
         expect.arrayContaining([
-          expect.stringContaining(`must be one of "tree" or "flat"`),
+          expect.stringContaining(`must be one of "tree", "flat" or "id"`),
         ]),
       );
     });
@@ -129,6 +129,24 @@ describe("configuration", () => {
       expect(cleanLogs(logs)).toEqual(
         expect.arrayContaining([
           expect.stringContaining(`File pattern can't be empty in flat mode`),
+        ]),
+      );
+    });
+
+    it("should fail and throw log error when mode is id and filesPattern is empty", async () => {
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--mode=id"],
+        {
+          cwd: getFixtureFolder("basic"),
+          silent: true,
+        },
+      );
+      const { exitCode, logs } = await cli.run();
+
+      expect(exitCode).toBe(1);
+      expect(cleanLogs(logs)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(`File pattern can't be empty in id mode`),
         ]),
       );
     });

--- a/components/markdown-confluence-sync/test/component/specs/flat.spec.ts
+++ b/components/markdown-confluence-sync/test/component/specs/flat.spec.ts
@@ -16,256 +16,139 @@ import {
   getFixtureFolder,
 } from "../support/Paths";
 
-describe("markdown-confluence-sync binary", () => {
+describe("markdown-confluence-sync binary with flat mode active", () => {
   let cli: ChildProcessManagerInterface;
   let logs: string[];
   let exitCode: number | null;
   let createRequests: SpyRequest[];
 
-  describe("with flat mode active", () => {
-    describe("when no file pattern is provided", () => {
-      beforeAll(async () => {
-        await changeMockCollection("with-mdx-files");
-        await resetRequests();
+  describe("when no file pattern is provided", () => {
+    beforeAll(async () => {
+      await changeMockCollection("with-mdx-files");
+      await resetRequests();
 
-        cli = new ChildProcessManager(
-          [getBinaryPathFromFixtureFolder(), "--mode=flat"],
-          {
-            cwd: getFixtureFolder("mock-server-with-mdx-files"),
-            silent: true,
-            env: {
-              MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
-            },
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--mode=flat"],
+        {
+          cwd: getFixtureFolder("mock-server-with-mdx-files"),
+          silent: true,
+          env: {
+            MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
           },
-        );
+        },
+      );
 
-        const result = await cli.run();
-        logs = result.logs;
-        exitCode = result.exitCode;
-      });
-
-      afterAll(async () => {
-        await cli.kill();
-      });
-
-      it("should have exit code 1", async () => {
-        expect(exitCode).toBe(1);
-      });
-
-      it("should fail and throw error because file pattern can't be empty", async () => {
-        expect(cleanLogs(logs)).toEqual(
-          expect.arrayContaining([
-            expect.stringContaining(`File pattern can't be empty in flat mode`),
-          ]),
-        );
-      });
+      const result = await cli.run();
+      logs = result.logs;
+      exitCode = result.exitCode;
     });
 
-    describe("when filesPattern option found more than one page", () => {
-      beforeAll(async () => {
-        await changeMockCollection("with-confluence-page-id");
-        await resetRequests();
-
-        cli = new ChildProcessManager(
-          [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild1*"],
-          {
-            cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
-            silent: true,
-            env: {
-              MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
-              MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
-              MARKDOWN_CONFLUENCE_SYNC_CONFLUENCE_ROOT_PAGE_ID: "foo-root-id",
-            },
-          },
-        );
-
-        const result = await cli.run();
-        logs = result.logs;
-        exitCode = result.exitCode;
-
-        createRequests = await getRequestsByRouteId("confluence-create-page");
-      });
-
-      afterAll(async () => {
-        await cli.kill();
-      });
-
-      it("should have exit code 0", async () => {
-        expect(exitCode).toBe(0);
-      });
-
-      it("should display a log text containing 'matching the pattern", async () => {
-        expect(cleanLogs(logs)).toEqual(
-          expect.arrayContaining([
-            expect.stringContaining(`matching the pattern`),
-          ]),
-        );
-      });
-
-      it("you should have created 3 pages that have ancestors with the root page id", async () => {
-        const ancestors = [{ id: "foo-root-id" }];
-
-        expect(createRequests).toHaveLength(3);
-        expect(createRequests.at(0)?.body?.ancestors).toStrictEqual(ancestors);
-        expect(createRequests.at(1)?.body?.ancestors).toStrictEqual(ancestors);
-        expect(createRequests.at(2)?.body?.ancestors).toStrictEqual(ancestors);
-      });
+    afterAll(async () => {
+      await cli.kill();
     });
 
-    describe("when the options have the option filesPattern and no rootPageId", () => {
-      let updateRequest: SpyRequest[];
-
-      beforeAll(async () => {
-        await changeMockCollection("with-confluence-page-id");
-        await resetRequests();
-
-        cli = new ChildProcessManager(
-          [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild2*"],
-          {
-            cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
-            silent: true,
-            env: {
-              MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
-              MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
-            },
-          },
-        );
-
-        const result = await cli.run();
-        logs = result.logs;
-        exitCode = result.exitCode;
-        updateRequest = await getRequestsByRouteId("confluence-update-page");
-      });
-
-      afterAll(async () => {
-        await cli.kill();
-      });
-
-      it("should have exit code 0", async () => {
-        expect(exitCode).toBe(0);
-      });
-
-      it("should have updated 1 page with the confluence page identifier given in the file", async () => {
-        expect(updateRequest).toHaveLength(1);
-      });
+    it("should have exit code 1", async () => {
+      expect(exitCode).toBe(1);
     });
 
-    describe("when filesPattern option searches for a txt file", () => {
-      beforeAll(async () => {
-        await changeMockCollection("with-confluence-page-id");
-        await resetRequests();
+    it("should fail and throw error because file pattern can't be empty", async () => {
+      expect(cleanLogs(logs)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(`File pattern can't be empty in flat mode`),
+        ]),
+      );
+    });
+  });
 
-        cli = new ChildProcessManager(
-          [
-            getBinaryPathFromFixtureFolder(),
-            "--filesPattern=**/grandChild1.txt",
-          ],
-          {
-            cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
-            silent: true,
-            env: {
-              MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
-              MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
-            },
+  describe("when filesPattern option found more than one page", () => {
+    beforeAll(async () => {
+      await changeMockCollection("with-confluence-page-id");
+      await resetRequests();
+
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild1*"],
+        {
+          cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
+          silent: true,
+          env: {
+            MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
+            MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
+            MARKDOWN_CONFLUENCE_SYNC_CONFLUENCE_ROOT_PAGE_ID: "foo-root-id",
           },
-        );
+        },
+      );
 
-        const result = await cli.run();
-        logs = result.logs;
-        exitCode = result.exitCode;
+      const result = await cli.run();
+      logs = result.logs;
+      exitCode = result.exitCode;
 
-        createRequests = await getRequestsByRouteId("confluence-create-page");
-      });
-
-      afterAll(async () => {
-        await cli.kill();
-      });
-
-      it("should have exit code 0", async () => {
-        expect(exitCode).toBe(0);
-      });
-
-      it("should not have created pages because the file filter is looking for md or mdx files", async () => {
-        expect(createRequests).toHaveLength(0);
-      });
+      createRequests = await getRequestsByRouteId("confluence-create-page");
     });
 
-    describe("when filesPattern option searches files with 'check' pattern", () => {
-      beforeAll(async () => {
-        await changeMockCollection("with-confluence-page-id");
-        await resetRequests();
-
-        cli = new ChildProcessManager(
-          [getBinaryPathFromFixtureFolder(), "--filesPattern=**/check*"],
-          {
-            cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
-            silent: true,
-            env: {
-              MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
-              MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
-            },
-          },
-        );
-
-        const result = await cli.run();
-        logs = result.logs;
-        exitCode = result.exitCode;
-
-        createRequests = await getRequestsByRouteId("confluence-create-page");
-      });
-
-      afterAll(async () => {
-        await cli.kill();
-      });
-
-      it("should have exit code 0", async () => {
-        expect(exitCode).toBe(0);
-      });
-
-      it("should not have created pages because files not matches pattern", async () => {
-        expect(createRequests).toHaveLength(0);
-      });
+    afterAll(async () => {
+      await cli.kill();
     });
 
-    describe("when no rootPageId is provided and there are pages without confluence id", () => {
-      beforeAll(async () => {
-        await changeMockCollection("with-confluence-page-id");
-        await resetRequests();
+    it("should have exit code 0", async () => {
+      expect(exitCode).toBe(0);
+    });
 
-        cli = new ChildProcessManager(
-          [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild1*"],
-          {
-            cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
-            silent: true,
-            env: {
-              MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
-              MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
-            },
+    it("should display a log text containing 'matching the pattern", async () => {
+      expect(cleanLogs(logs)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(`matching the pattern`),
+        ]),
+      );
+    });
+
+    it("you should have created 3 pages that have ancestors with the root page id", async () => {
+      const ancestors = [{ id: "foo-root-id" }];
+
+      expect(createRequests).toHaveLength(3);
+      expect(createRequests.at(0)?.body?.ancestors).toStrictEqual(ancestors);
+      expect(createRequests.at(1)?.body?.ancestors).toStrictEqual(ancestors);
+      expect(createRequests.at(2)?.body?.ancestors).toStrictEqual(ancestors);
+    });
+  });
+
+  describe("when no rootPageId is provided and there are pages without confluence id", () => {
+    beforeAll(async () => {
+      await changeMockCollection("with-confluence-page-id");
+      await resetRequests();
+
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild1*"],
+        {
+          cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
+          silent: true,
+          env: {
+            MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
+            MARKDOWN_CONFLUENCE_SYNC_MODE: "flat",
           },
-        );
+        },
+      );
 
-        const result = await cli.run();
-        logs = result.logs;
-        exitCode = result.exitCode;
+      const result = await cli.run();
+      logs = result.logs;
+      exitCode = result.exitCode;
 
-        createRequests = await getRequestsByRouteId("confluence-create-page");
-      });
+      createRequests = await getRequestsByRouteId("confluence-create-page");
+    });
 
-      afterAll(async () => {
-        await cli.kill();
-      });
+    afterAll(async () => {
+      await cli.kill();
+    });
 
-      it("should have exit code 1", async () => {
-        expect(exitCode).toBe(1);
-      });
+    it("should have exit code 1", async () => {
+      expect(exitCode).toBe(1);
+    });
 
-      it("should display a log text containing 'when there are pages without an id' because all pages haven't confluence pages ids", async () => {
-        expect(cleanLogs(logs)).toEqual(
-          expect.arrayContaining([
-            expect.stringContaining(`when there are pages without an id`),
-          ]),
-        );
-      });
+    it("should display a log text containing 'when there are pages without an id' because all pages haven't confluence pages ids", async () => {
+      expect(cleanLogs(logs)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(`when there are pages without an id`),
+        ]),
+      );
     });
   });
 });

--- a/components/markdown-confluence-sync/test/component/specs/id.spec.ts
+++ b/components/markdown-confluence-sync/test/component/specs/id.spec.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChildProcessManagerInterface } from "@tid-xcut/child-process-manager";
+import { ChildProcessManager } from "@tid-xcut/child-process-manager";
+
+import {
+  changeMockCollection,
+  getRequestsByRouteId,
+  resetRequests,
+} from "../support/Mock";
+import type { SpyRequest } from "../support/Mock.types";
+import {
+  getBinaryPathFromFixtureFolder,
+  getFixtureFolder,
+} from "../support/Paths";
+
+describe("markdown-confluence-sync binary with id mode active", () => {
+  let cli: ChildProcessManagerInterface;
+  let exitCode: number | null;
+  let createRequests: SpyRequest[];
+
+  describe("when the options have the option filesPattern and no rootPageId", () => {
+    let updateRequest: SpyRequest[];
+
+    beforeAll(async () => {
+      await changeMockCollection("with-confluence-page-id");
+      await resetRequests();
+
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild2*"],
+        {
+          cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
+          silent: true,
+          env: {
+            MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
+            MARKDOWN_CONFLUENCE_SYNC_MODE: "id",
+          },
+        },
+      );
+
+      const result = await cli.run();
+      exitCode = result.exitCode;
+      updateRequest = await getRequestsByRouteId("confluence-update-page");
+    });
+
+    afterAll(async () => {
+      await cli.kill();
+    });
+
+    it("should have exit code 0", async () => {
+      expect(exitCode).toBe(0);
+    });
+
+    it("should have updated 1 page with the confluence page identifier given in the file", async () => {
+      expect(updateRequest).toHaveLength(1);
+    });
+  });
+
+  describe("when filesPattern option searches for a txt file", () => {
+    beforeAll(async () => {
+      await changeMockCollection("with-confluence-page-id");
+      await resetRequests();
+
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--filesPattern=**/grandChild1.txt"],
+        {
+          cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
+          silent: true,
+          env: {
+            MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
+            MARKDOWN_CONFLUENCE_SYNC_MODE: "id",
+          },
+        },
+      );
+
+      const result = await cli.run();
+      exitCode = result.exitCode;
+
+      createRequests = await getRequestsByRouteId("confluence-create-page");
+    });
+
+    afterAll(async () => {
+      await cli.kill();
+    });
+
+    it("should have exit code 0", async () => {
+      expect(exitCode).toBe(0);
+    });
+
+    it("should not have created pages because the file filter is looking for md or mdx files", async () => {
+      expect(createRequests).toHaveLength(0);
+    });
+  });
+
+  describe("when filesPattern option searches files with 'check' pattern", () => {
+    beforeAll(async () => {
+      await changeMockCollection("with-confluence-page-id");
+      await resetRequests();
+
+      cli = new ChildProcessManager(
+        [getBinaryPathFromFixtureFolder(), "--filesPattern=**/check*"],
+        {
+          cwd: getFixtureFolder("mock-server-with-confluence-page-id"),
+          silent: true,
+          env: {
+            MARKDOWN_CONFLUENCE_SYNC_LOG_LEVEL: "debug",
+            MARKDOWN_CONFLUENCE_SYNC_MODE: "id",
+          },
+        },
+      );
+
+      const result = await cli.run();
+      exitCode = result.exitCode;
+
+      createRequests = await getRequestsByRouteId("confluence-create-page");
+    });
+
+    afterAll(async () => {
+      await cli.kill();
+    });
+
+    it("should have exit code 0", async () => {
+      expect(exitCode).toBe(0);
+    });
+
+    it("should not have created pages because files not matches pattern", async () => {
+      expect(createRequests).toHaveLength(0);
+    });
+  });
+});

--- a/components/markdown-confluence-sync/test/unit/specs/docusaurus/DocusaurusPagesFactory.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/docusaurus/DocusaurusPagesFactory.test.ts
@@ -29,7 +29,7 @@ describe("docusaurusPagesFactory", () => {
     docusaurusPagesOptions = { config: namespace, logger };
   });
 
-  it(`should throw error with text "must be one of "tree" or "flat" when mode isn't valid mode`, async () => {
+  it(`should throw error with text "must be one of "tree", "flat" or "id" when mode isn't valid mode`, async () => {
     await expect(async () =>
       MarkdownDocumentsFactory.fromMode(
         "foo" as SyncModes,
@@ -37,7 +37,9 @@ describe("docusaurusPagesFactory", () => {
       ),
     ).rejects.toThrow(
       expect.objectContaining({
-        message: expect.stringContaining(`must be one of "tree" or "flat"`),
+        message: expect.stringContaining(
+          `must be one of "tree", "flat" or "id"`,
+        ),
       }),
     );
   });

--- a/components/markdown-confluence-sync/test/unit/specs/docusaurus/pages/support/remark/remark-validate-frontmatter.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/docusaurus/pages/support/remark/remark-validate-frontmatter.test.ts
@@ -17,7 +17,7 @@ describe("remark-validate-frontmatter", () => {
     expect(remarkValidateFrontmatter).toBeDefined();
   });
 
-  it("should fail if the file fails FrontMatter validation", () => {
+  it("should not fail if the file does not have FrontMatter data", () => {
     // Arrange
     const invalidMarkdown = dedent`
       ---
@@ -36,13 +36,14 @@ describe("remark-validate-frontmatter", () => {
         .use(remarkParseFrontmatter)
         .use(remarkValidateFrontmatter, FrontMatterValidator)
         .processSync(new VFile(invalidMarkdown)),
-    ).toThrow();
+    ).not.toThrow();
   });
 
-  it("should fail if it does not include a FrontMatter validation", () => {
+  it("should fail if it has frontmatter data and does not include a FrontMatter validation", () => {
     // Arrange
     const invalidMarkdown = dedent`
       ---
+      title: My Title
       ---
 
       # My Title

--- a/components/markdown-confluence-sync/test/unit/specs/docusaurus/tree/DocusaurusDocTreeCategory.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/docusaurus/tree/DocusaurusDocTreeCategory.test.ts
@@ -11,10 +11,10 @@ import { dedent } from "ts-dedent";
 import { TempFiles } from "@support/utils/TempFiles";
 const { dirSync, fileSync } = new TempFiles();
 
-import { InvalidMarkdownFormatException } from "@src/lib/docusaurus/pages/errors/InvalidMarkdownFormatException";
 import { InvalidPathException } from "@src/lib/docusaurus/pages/errors/InvalidPathException";
 import { PathNotExistException } from "@src/lib/docusaurus/pages/errors/PathNotExistException";
 import { DocusaurusDocTreeCategory } from "@src/lib/docusaurus/tree/DocusaurusDocTreeCategory";
+import { TitleRequiredException } from "@src/lib/docusaurus/pages/errors/TitleRequiredException";
 
 describe("docusaurusDocTreeCategory", () => {
   let dir: DirResult;
@@ -48,7 +48,7 @@ describe("docusaurusDocTreeCategory", () => {
     );
   });
 
-  it("should fail if the path index.md file does not have a valid format", () => {
+  it("should fail if the path index.md file does not have title defined", () => {
     // Arrange
     const categoryDir = dirSync({ dir: dir.name });
     const categoryIndex = fileSync({ dir: categoryDir.name, name: "index.md" });
@@ -57,7 +57,7 @@ describe("docusaurusDocTreeCategory", () => {
     // Act
     // Assert
     expect(() => new DocusaurusDocTreeCategory(categoryDir.name)).toThrow(
-      InvalidMarkdownFormatException,
+      TitleRequiredException,
     );
   });
 


### PR DESCRIPTION
## Package confluence-sync v1.0.0

### Added

* feat: Add "id" mode, which only allows to update pages by its Confluence page ID. It throws when there is a page without an ID or with an ancestor, or when rootPageId is provided.
* feat: Do not allow "flat" mode when all pages have an id. "id" mode should be used instead.
* feat: Validate sync modes at the very beginning. It throws when a non-existing mode is provided.

## Package markdown-confluence-sync v1.0.0

### Added

* feat: Add id mode. Upgrade confluence-sync to 1.0.0.
* feat: Add filesMetadata option, enabling to defined the metadata of the files using the configuration file.

### Changed

* chore: Remove frontmatter properties from docs. Use filesMetadata instead to define the metadata of the files when syncing them to Confluence.

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](./.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](./.github/CODE_OF_CONDUCT.md) document
* [x] I accept that, by signing the Contributor License Agreement through a comment in the PR, my Github user name will be stored by in a branch of this repository for future reference.

In case this is your first contribution to this project, you will also have to **add a comment with the following text: "_I have read the CLA Document and I hereby sign the CLA_"**, otherwise the PR status will fail and our bot will request you to add it. Once you have signed it in a PR, you will not have to sign it again for future contributions.
