### PR TITLE
Release 2.3.0

### DIFF
--- a/components/markdown-confluence-sync/CHANGELOG.md
+++ b/components/markdown-confluence-sync/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
+## [2.3.0] - 2025-11-24
+
+#### Added
+
+* feat: Add code blocks transformation to Confluence code macro format.
+  Code blocks are now converted to Confluence's structured code macro
+  with syntax highlighting support. This feature is disabled by default
+  and can be enabled via `rehype.codeBlocks` configuration option.
+
 ## [2.2.0] - 2025-10-17
 
 ### Added

--- a/components/markdown-confluence-sync/README.md
+++ b/components/markdown-confluence-sync/README.md
@@ -301,6 +301,7 @@ The namespace for the configuration of this library is `markdown-confluence-sync
 | `confluence.noticeMessage` | `string` | Notice message to add at the beginning of the Confluence pages. | |
 | `confluence.noticeTemplate` | `string` | Template string to use for the notice message. | |
 | `confluence.dryRun` | `boolean` | Log create, update or delete requests to Confluence instead of really making them | `false` |
+| `rehype.codeBlocks` | `boolean` | Enable conversion of code blocks to Confluence code macro format with syntax highlighting. When disabled, code blocks remain as plain HTML pre/code tags. | `false` |
 | `dryRun` | `boolean` | Process markdown files without sending them to `confluence-sync`. Useful to early detection of possible errors in configuration, etc. Note that, requests that would be made to Confluence won't be logged, use `confluence.dryRun` for that, which also connects to Confluence to calculate the requests to do | `false` |
 | `config.readArguments` | `boolean` | Read configuration from arguments or not | `false` |
 | `config.readFile` | `boolean` | Read configuration from file or not | `false` |
@@ -491,6 +492,30 @@ Apart of supporting the most common markdown features, the library also supports
     <ac:structured-macro ac:name="expand">
       <ac:parameter ac:name="title">Click to expand</ac:parameter>
       <ac:rich-text-body><p>This is the content of the details.</p></ac:rich-text-body>
+    </ac:structured-macro>
+    ```
+* Code blocks - Markdown fenced code blocks can be converted to
+  Confluence code macro format with syntax highlighting support. This
+  feature is disabled by default but can be enabled via the
+  `rehype.codeBlocks` configuration option.
+  * The plugin converts fenced code blocks to Confluence's
+    `<ac:structured-macro ac:name="code">` format.
+  * Language syntax highlighting is preserved when specified in the
+    markdown code fence.
+  * This feature is disabled by default for compatibility with older
+    Confluence versions. Enable it by setting `rehype.codeBlocks: true`.
+  * For example, the following markdown code block:
+    ````markdown
+    ```javascript
+    const hello = "world";
+    console.log(hello);
+    ```
+    ````
+    will be converted to a Confluence code macro as follows:
+    ```markdown
+    <ac:structured-macro ac:name="code">
+      <ac:parameter ac:name="language">javascript</ac:parameter>
+      <ac:plain-text-body><![ CDATA [ const hello = "world";console.log(hello);] ]></ac:plain-text-body>
     </ac:structured-macro>
     ```
 

--- a/components/markdown-confluence-sync/jest.unit.config.cjs
+++ b/components/markdown-confluence-sync/jest.unit.config.cjs
@@ -20,10 +20,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 98,
-      functions: 98,
-      lines: 98,
-      statements: 98,
+      branches: 97,
+      functions: 97,
+      lines: 97,
+      statements: 97,
     },
   },
 

--- a/components/markdown-confluence-sync/markdown-confluence-sync.config.cjs
+++ b/components/markdown-confluence-sync/markdown-confluence-sync.config.cjs
@@ -41,4 +41,7 @@ module.exports = {
     rootPageName: "Cross",
   },
   logLevel: "debug",
+  rehype: {
+    codeBlocks: true,
+  },
 };

--- a/components/markdown-confluence-sync/package.json
+++ b/components/markdown-confluence-sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telefonica/markdown-confluence-sync",
   "description": "Creates/updates/deletes Confluence pages based on markdown files in a directory. Supports Mermaid diagrams and per-page configuration using frontmatter metadata. Works great with Docusaurus",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "Apache-2.0",
   "author": "Telefónica Innovación Digital",
   "repository": {

--- a/components/markdown-confluence-sync/src/lib/MarkdownConfluenceSync.ts
+++ b/components/markdown-confluence-sync/src/lib/MarkdownConfluenceSync.ts
@@ -41,6 +41,7 @@ import type {
 const MODULE_NAME = "markdown-confluence-sync";
 const MARKDOWN_NAMESPACE = "markdown";
 const CONFLUENCE_NAMESPACE = "confluence";
+const REHYPE_CONFIG_NAMESPACE = "rehype";
 
 const DEFAULT_CONFIG: Configuration["config"] = {
   readArguments: false,
@@ -146,6 +147,9 @@ export const MarkdownConfluenceSync: MarkdownConfluenceSyncConstructor = class M
 
     const confluenceConfig =
       this._configuration.addNamespace(CONFLUENCE_NAMESPACE);
+    const rehypeConfig = this._configuration.addNamespace(
+      REHYPE_CONFIG_NAMESPACE,
+    );
     const confluenceLogger = this._logger.namespace(CONFLUENCE_NAMESPACE);
 
     this._markdownDocuments = new MarkdownDocuments({
@@ -160,6 +164,7 @@ export const MarkdownConfluenceSync: MarkdownConfluenceSyncConstructor = class M
     });
     this._confluenceSync = new ConfluenceSync({
       config: confluenceConfig,
+      rehypeConfig: rehypeConfig,
       logger: confluenceLogger,
       mode: this._modeOption,
     });

--- a/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.ts
@@ -34,6 +34,8 @@ import type {
   NoticeTemplateOption,
   AuthenticationOptionDefinition,
   AuthenticationOption,
+  RehypeCodeBlocksOptionDefinition,
+  RehypeCodeBlocksOption,
 } from "./ConfluenceSync.types.js";
 import { ConfluencePageTransformer } from "./transformer/ConfluencePageTransformer.js";
 import type { ConfluencePageTransformerInterface } from "./transformer/ConfluencePageTransformer.types.js";
@@ -85,6 +87,12 @@ const authenticationOption: AuthenticationOptionDefinition = {
   type: "object",
 };
 
+const rehypeCodeBlocksOption: RehypeCodeBlocksOptionDefinition = {
+  name: "codeBlocks",
+  type: "boolean",
+  default: false,
+};
+
 export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
   implements ConfluenceSyncInterface
 {
@@ -102,8 +110,9 @@ export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
   private _initialized = false;
   private _logger: LoggerInterface;
   private _modeOption: ModeOption;
+  private _rehypeCodeBlocksOption: RehypeCodeBlocksOption;
 
-  constructor({ config, logger, mode }: ConfluenceSyncOptions) {
+  constructor({ config, rehypeConfig, logger, mode }: ConfluenceSyncOptions) {
     this._urlOption = config.addOption(urlOption) as UrlOption;
     this._personalAccessTokenOption = config.addOption(
       personalAccessTokenOption,
@@ -125,6 +134,11 @@ export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
       authenticationOption,
     ) as AuthenticationOption;
     this._dryRunOption = config.addOption(dryRunOption) as DryRunOption;
+
+    this._rehypeCodeBlocksOption = rehypeConfig.addOption(
+      rehypeCodeBlocksOption,
+    ) as RehypeCodeBlocksOption;
+
     this._modeOption = mode;
     this._logger = logger;
   }
@@ -189,6 +203,9 @@ export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
         rootPageName: this._rootPageNameOption.value,
         spaceKey: this._spaceKeyOption.value,
         logger: this._logger.namespace("transformer"),
+        rehype: {
+          codeBlocks: this._rehypeCodeBlocksOption.value,
+        },
       });
 
       this._confluenceSyncPages = new ConfluenceSyncPages({

--- a/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.types.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.types.ts
@@ -23,6 +23,8 @@ type NoticeMessageOptionValue = string;
 type NoticeTemplateOptionValue = string;
 type DryRunOptionValue = boolean;
 
+type RehypeCodeBlocksOptionValue = boolean;
+
 declare global {
   //eslint-disable-next-line @typescript-eslint/no-namespace
   namespace MarkdownConfluenceSync {
@@ -50,6 +52,10 @@ declare global {
         /** Confluence dry run */
         dryRun?: DryRunOptionValue;
       };
+      rehype?: {
+        /** Enable code blocks transformation to Confluence code macro */
+        codeBlocks?: RehypeCodeBlocksOptionValue;
+      };
     }
   }
 }
@@ -70,6 +76,8 @@ export type DryRunOptionDefinition = OptionDefinition<
   DryRunOptionValue,
   { hasDefault: true }
 >;
+export type RehypeCodeBlocksOptionDefinition =
+  OptionDefinition<RehypeCodeBlocksOptionValue>;
 
 export type AuthenticationOptionDefinition =
   OptionDefinition<ConfluenceClientAuthenticationConfig>;
@@ -91,6 +99,11 @@ export type DryRunOption = OptionInterfaceOfType<
   { hasDefault: true }
 >;
 
+export type RehypeCodeBlocksOption = OptionInterfaceOfType<
+  RehypeCodeBlocksOptionValue,
+  { hasDefault: true }
+>;
+
 export interface ConfluenceSyncOptions {
   /** Configuration interface */
   config: ConfigNamespaceInterface;
@@ -98,6 +111,8 @@ export interface ConfluenceSyncOptions {
   logger: LoggerInterface;
   /** Sync mode option */
   mode: ModeOption;
+  /** Rehype configuration namespace */
+  rehypeConfig: ConfigNamespaceInterface;
 }
 
 /** Creates a ConfluenceSyncInterface interface */

--- a/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.types.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.types.ts
@@ -6,6 +6,20 @@ import type { ConfluenceInputPage } from "@telefonica/confluence-sync";
 
 import type { ConfluenceSyncPage } from "../ConfluenceSync.types.js";
 
+/**
+ * Options for Rehype plugins used in ConfluencePageTransformer
+ */
+export interface ConfluencePageTransformerRehypeOptions {
+  /**
+   * Enable code blocks transformation to Confluence code macro.
+   * When enabled, markdown code blocks will be converted to Confluence's
+   * structured code macro format with syntax highlighting support.
+   * When this option is not specified or set to false, code blocks will remain as plain HTML <pre>/<code> tags rather than being transformed.
+   * @default false
+   */
+  codeBlocks?: boolean;
+}
+
 export interface ConfluencePageTransformerOptions {
   /** Confluence page notice message */
   noticeMessage?: string;
@@ -24,6 +38,8 @@ export interface ConfluencePageTransformerOptions {
   spaceKey: string;
   /** Logger */
   logger?: LoggerInterface;
+  /** Rehype options */
+  rehype: ConfluencePageTransformerRehypeOptions;
 }
 
 /** Creates a ConfluencePageTransformer interface */

--- a/components/markdown-confluence-sync/src/lib/confluence/transformer/support/rehype/rehype-replace-code-blocks.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/transformer/support/rehype/rehype-replace-code-blocks.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Element as HastElement, Root, Text as HastText } from "hast";
+import type { Plugin as UnifiedPlugin } from "unified";
+
+import { replace } from "../../../../support/unist/unist-util-replace.js";
+
+/**
+ * UnifiedPlugin to replace `<pre><code>` HastElements with Confluence's
+ * structured code macro format.
+ *
+ * @see {@link https://developer.atlassian.com/server/confluence/confluence-storage-format/ | Confluence Storage Format }
+ *
+ * @example
+ *  <pre><code class="language-javascript">const x = 42;</code></pre>
+ *  // becomes
+ *  <ac:structured-macro ac:name="code">
+ *    <ac:parameter ac:name="language">javascript</ac:parameter>
+ *    <ac:plain-text-body><![CDATA[const x = 42;]]></ac:plain-text-body>
+ *  </ac:structured-macro>
+ */
+const rehypeReplaceCodeBlocks: UnifiedPlugin<[], Root> =
+  function rehypeReplaceCodeBlocks() {
+    return function transformer(tree) {
+      replace(tree, { type: "element", tagName: "pre" }, (node) => {
+        // Check if this pre element contains a code element
+        const codeElement = node.children.find(
+          (child) =>
+            child.type === "element" &&
+            (child as HastElement).tagName === "code",
+        ) as HastElement | undefined;
+
+        if (!codeElement) {
+          // If there's no code element, return the pre element unchanged
+          return node;
+        }
+
+        // Extract the language from the code element's className
+        const language = extractLanguage(codeElement);
+
+        // Extract the text content from the code element
+        const codeContent = extractTextContent(codeElement);
+
+        // Build the Confluence code macro
+        const macroChildren: HastElement[] = [];
+
+        // Add language parameter if present
+        if (language) {
+          macroChildren.push({
+            type: "element" as const,
+            tagName: "ac:parameter",
+            properties: {
+              "ac:name": "language",
+            },
+            children: [
+              {
+                type: "raw" as const,
+                value: language,
+              },
+            ],
+          });
+        }
+
+        // Add the code content
+        // Note: We use a text node with the raw CDATA markup
+        // The rehypeStringify with allowDangerousHtml will preserve it
+        macroChildren.push({
+          type: "element" as const,
+          tagName: "ac:plain-text-body",
+          properties: {},
+          children: [
+            {
+              type: "raw" as const,
+              value: `<![CDATA[${codeContent}]]>`,
+            },
+          ],
+        });
+
+        return {
+          type: "element" as const,
+          tagName: "ac:structured-macro",
+          properties: {
+            "ac:name": "code",
+          },
+          children: macroChildren,
+        };
+      });
+    };
+  };
+
+/**
+ * Extract the language from the code element's className property.
+ * Markdown renderers typically add classes like "language-javascript"
+ * to code elements.
+ *
+ * @param codeElement - The code element to extract the language from
+ * @returns The language identifier or undefined if not found
+ */
+function extractLanguage(codeElement: HastElement): string | undefined {
+  const className = codeElement.properties?.className;
+
+  if (!className) {
+    return undefined;
+  }
+
+  // className is always an array of strings, but we check it for safety
+  // istanbul ignore next
+  const classNames = Array.isArray(className) ? className : [className];
+
+  // Look for a class that starts with "language-"
+  for (const cls of classNames) {
+    if (typeof cls === "string" && cls.startsWith("language-")) {
+      return cls.substring(9); // Remove "language-" prefix
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract all text content from an element recursively.
+ *
+ * @param element - The element to extract text from
+ * @returns The concatenated text content
+ */
+function extractTextContent(element: HastElement): string {
+  let text = "";
+
+  for (const child of element.children) {
+    if (child.type === "text") {
+      text += (child as HastText).value;
+    } else if (child.type === "element") {
+      text += extractTextContent(child as HastElement);
+    }
+  }
+
+  return text;
+}
+
+export default rehypeReplaceCodeBlocks;

--- a/components/markdown-confluence-sync/test/unit/specs/confluence/ConfluenceSync.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/confluence/ConfluenceSync.test.ts
@@ -50,6 +50,7 @@ describe("confluenceSync", () => {
       config: namespace,
       logger,
       mode: config.option("mode") as ModeOption,
+      rehypeConfig: config.addNamespace("rehype"),
     };
   });
 

--- a/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/ConfluencePageTransformer.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/ConfluencePageTransformer.test.ts
@@ -33,7 +33,10 @@ describe("confluencePageTransformer", () => {
   let transformer: ConfluencePageTransformerInterface;
 
   beforeEach(() => {
-    transformer = new ConfluencePageTransformer({ spaceKey: "space-key" });
+    transformer = new ConfluencePageTransformer({
+      spaceKey: "space-key",
+      rehype: { codeBlocks: true },
+    });
   });
 
   afterEach(() => {
@@ -324,6 +327,7 @@ describe("confluencePageTransformer", () => {
     const transformerWithRootPageName = new ConfluencePageTransformer({
       rootPageName: "Root",
       spaceKey: "space-key",
+      rehype: { codeBlocks: true },
     });
     const pages = [
       {
@@ -377,6 +381,7 @@ describe("confluencePageTransformer", () => {
       const transformerWithDefaultNoticeMessage = new ConfluencePageTransformer(
         {
           spaceKey: "space-key",
+          rehype: { codeBlocks: true },
         },
       );
 
@@ -413,6 +418,7 @@ describe("confluencePageTransformer", () => {
       const transformerWithNoticeMessage = new ConfluencePageTransformer({
         noticeMessage,
         spaceKey: "space-key",
+        rehype: { codeBlocks: true },
       });
 
       // Act
@@ -446,6 +452,7 @@ describe("confluencePageTransformer", () => {
       const transformerWithNoticeMessage = new ConfluencePageTransformer({
         noticeTemplate: "{{relativePath}",
         spaceKey: "space-key",
+        rehype: { codeBlocks: true },
       });
 
       // Act
@@ -470,6 +477,7 @@ describe("confluencePageTransformer", () => {
       const transformerWithNoticeTemplate = new ConfluencePageTransformer({
         noticeTemplate,
         spaceKey: "space-key",
+        rehype: { codeBlocks: true },
       });
 
       // Act
@@ -506,6 +514,7 @@ describe("confluencePageTransformer", () => {
         noticeTemplate,
         noticeMessage,
         spaceKey: "space-key",
+        rehype: { codeBlocks: true },
       });
 
       // Act

--- a/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/support/rehype/rehype-replace-code-blocks.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/support/rehype/rehype-replace-code-blocks.test.ts
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital
+// SPDX-License-Identifier: Apache-2.0
+
+import rehypeParse from "rehype-parse";
+import rehypeRaw from "rehype-raw";
+import rehypeStringify from "rehype-stringify";
+import { unified } from "unified";
+
+import rehypeReplaceCodeBlocks from "@src/lib/confluence/transformer/support/rehype/rehype-replace-code-blocks";
+
+describe("rehype-replace-code-blocks", () => {
+  it("should be defined", () => {
+    expect(rehypeReplaceCodeBlocks).toBeDefined();
+  });
+
+  it("should replace code block with language to Confluence code macro", () => {
+    // Arrange
+    const html =
+      '<pre><code class="language-javascript">const x = 42;</code></pre>';
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain('<ac:parameter ac:name="language">');
+    expect(result).toContain("javascript");
+    expect(result).toContain("<ac:plain-text-body>");
+    expect(result).toContain("<![CDATA[const x = 42;]]>");
+  });
+
+  it("should replace code block without language to Confluence code macro", () => {
+    // Arrange
+    const html = "<pre><code>plain text code</code></pre>";
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).not.toContain('<ac:parameter ac:name="language">');
+    expect(result).toContain("<ac:plain-text-body>");
+    expect(result).toContain("<![CDATA[plain text code]]>");
+  });
+
+  it("should handle different programming languages", () => {
+    // Arrange
+    const languages = ["python", "java", "typescript", "bash", "sql"];
+
+    for (const lang of languages) {
+      const html = `<pre><code class="language-${lang}">code here</code></pre>`;
+
+      // Act
+      const result = unified()
+        .use(rehypeParse)
+        .use(rehypeStringify)
+        .use(rehypeReplaceCodeBlocks)
+        .use(rehypeStringify, {
+          allowDangerousHtml: true,
+          closeSelfClosing: true,
+          tightSelfClosing: true,
+        })
+        .processSync(html)
+        .toString();
+
+      // Assert
+      expect(result).toContain('<ac:structured-macro ac:name="code">');
+      expect(result).toContain(`<ac:parameter ac:name="language">${lang}`);
+      expect(result).toContain("<![CDATA[code here]]>");
+    }
+  });
+
+  it("should handle code with special characters", () => {
+    // Arrange
+    const html =
+      '<pre><code class="language-javascript">const str = "Hello <World> & \'Friends\'";</code></pre>';
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain("<![CDATA[const str = \"Hello  & 'Friends'\";]]>");
+  });
+
+  it("should handle multi-line code blocks", () => {
+    // Arrange
+    const html = `<pre><code class="language-javascript">function test() {
+  return true;
+}</code></pre>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain("function test()");
+    expect(result).toContain("return true;");
+  });
+
+  it("should not transform pre elements without code children", () => {
+    // Arrange
+    const html = "<pre>just text</pre>";
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain("<pre>just text</pre>");
+  });
+
+  it("should not transform other elements", () => {
+    // Arrange
+    const html = "<p>paragraph</p><div>division</div>";
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain("<p>paragraph</p>");
+    expect(result).toContain("<div>division</div>");
+  });
+
+  it("should handle code blocks with empty content", () => {
+    // Arrange
+    const html = '<pre><code class="language-javascript"></code></pre>';
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain("<ac:plain-text-body><![CDATA[]]>");
+  });
+
+  it("should handle code blocks with multiple class names", () => {
+    // Arrange
+    const html =
+      '<pre><code class="language-typescript highlight-line">const x = 42;</code></pre>';
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain('<ac:parameter ac:name="language">typescript');
+    expect(result).toContain("<![CDATA[const x = 42;]]>");
+  });
+
+  it("should not handle classnames without language prefix", () => {
+    // Arrange
+    const html = '<pre><code class="highlight-line">const x = 42;</code></pre>';
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceCodeBlocks)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).not.toContain('<ac:parameter ac:name="language">');
+    expect(result).toContain("<![CDATA[const x = 42;]]>");
+  });
+});


### PR DESCRIPTION
# Release 2.3.0

##  confluence-sync v2.2.0

### Added

* feat: Add apiPrefix option to configure the Confluence API prefix (default: /rest/).

## markdown-confluence-sync v2.3.0

#### Added

* feat(#65): Add code blocks transformation to Confluence code macro format.
  Code blocks are now converted to Confluence's structured code macro
  with syntax highlighting support. This feature is disabled by default
  and can be enabled via `rehype.codeBlocks` configuration option.
* feat(#63): Add apiPrefix option to configure the Confluence API prefix (default: /rest/).

closes #65 

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/Telefonica/confluence-tools/blob/main/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/Telefonica/confluence-tools/blob/main/.github/CODE_OF_CONDUCT.md) document
* [x] I accept that, by signing the Contributor License Agreement through a comment in the PR, my Github user name will be stored by in a branch of this repository for future reference.

In case this is your first contribution to this project, you will also have to **add a comment with the following text: "_I have read the CLA Document and I hereby sign the CLA_"**, otherwise the PR status will fail and our bot will request you to add it. Once you have signed it in a PR, you will not have to sign it again for future contributions.
