### PR TITLE
markdown-confluence-sync v2.4.0

### DIFF
--- a/components/cspell-config/dictionaries/missing-en.txt
+++ b/components/cspell-config/dictionaries/missing-en.txt
@@ -1,0 +1,1 @@
+blockquotes

--- a/components/markdown-confluence-sync/CHANGELOG.md
+++ b/components/markdown-confluence-sync/CHANGELOG.md
@@ -11,9 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
-## Unreleased
+## [2.4.0] - 2025-11-27
 
 #### Added
+
+* feat(#70): Add GitHub alerts transformation to Confluence macros.
+  GitHub-flavored markdown alerts ([!NOTE], [!TIP], [!IMPORTANT],
+  [!WARNING], [!CAUTION]) are now converted to Confluence's native
+  info, note, warning, and tip macros. This feature is disabled by
+  default and can be enabled via `rehype.alerts` configuration option.
 
 ## [2.3.0] - 2025-11-24
 

--- a/components/markdown-confluence-sync/README.md
+++ b/components/markdown-confluence-sync/README.md
@@ -303,6 +303,7 @@ The namespace for the configuration of this library is `markdown-confluence-sync
 | `confluence.noticeTemplate` | `string` | Template string to use for the notice message. | |
 | `confluence.dryRun` | `boolean` | Log create, update or delete requests to Confluence instead of really making them | `false` |
 | `rehype.codeBlocks` | `boolean` | Enable conversion of code blocks to Confluence code macro format with syntax highlighting. When disabled, code blocks remain as plain HTML pre/code tags. | `false` |
+| `rehype.githubAlerts` | `boolean` | Enable conversion of GitHub alerts ([!NOTE], [!TIP], [!IMPORTANT], [!WARNING], [!CAUTION]) to Confluence info/note/warning/tip macros. When disabled, github alerts remain as blockquotes. | `false` |
 | `dryRun` | `boolean` | Process markdown files without sending them to `confluence-sync`. Useful to early detection of possible errors in configuration, etc. Note that, requests that would be made to Confluence won't be logged, use `confluence.dryRun` for that, which also connects to Confluence to calculate the requests to do | `false` |
 | `config.readArguments` | `boolean` | Read configuration from arguments or not | `false` |
 | `config.readFile` | `boolean` | Read configuration from file or not | `false` |
@@ -495,7 +496,7 @@ Apart of supporting the most common markdown features, the library also supports
       <ac:rich-text-body><p>This is the content of the details.</p></ac:rich-text-body>
     </ac:structured-macro>
     ```
-* Code blocks - Markdown fenced code blocks can be converted to
+* [Code blocks](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks) - Markdown fenced code blocks can be converted to
   Confluence code macro format with syntax highlighting support. This
   feature is disabled by default but can be enabled via the
   `rehype.codeBlocks` configuration option.
@@ -517,6 +518,33 @@ Apart of supporting the most common markdown features, the library also supports
     <ac:structured-macro ac:name="code">
       <ac:parameter ac:name="language">javascript</ac:parameter>
       <ac:plain-text-body><![ CDATA [ const hello = "world";console.log(hello);] ]></ac:plain-text-body>
+    </ac:structured-macro>
+    ```
+* [GitHub Alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) - GitHub-flavored markdown alerts can be converted to
+  Confluence's native info, note, warning, and tip macros. This feature
+  is disabled by default but can be enabled via the `rehype.githubAlerts`
+  configuration option.
+  * The plugin converts GitHub alert syntax (`[!NOTE]`, `[!TIP]`,
+    `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`) to appropriate
+    Confluence macros.
+  * Alert content including formatted text, code, and lists is
+    preserved in the conversion.
+  * This feature is disabled by default for backward compatibility.
+    Enable it by setting `rehype.githubAlerts: true`.
+  * For example, the following markdown alert:
+    ```markdown
+    > [!NOTE]
+    > Useful information that users should know, even when skimming
+    > content.
+    ```
+    will be converted to a Confluence info macro as follows:
+    ```markdown
+    <ac:structured-macro ac:name="info">
+      <ac:parameter ac:name="title">Note</ac:parameter>
+      <ac:rich-text-body>
+        <p>Useful information that users should know, even when skimming
+        content.</p>
+      </ac:rich-text-body>
     </ac:structured-macro>
     ```
 

--- a/components/markdown-confluence-sync/markdown-confluence-sync.config.cjs
+++ b/components/markdown-confluence-sync/markdown-confluence-sync.config.cjs
@@ -43,5 +43,6 @@ module.exports = {
   logLevel: "debug",
   rehype: {
     codeBlocks: true,
+    githubAlerts: true,
   },
 };

--- a/components/markdown-confluence-sync/package.json
+++ b/components/markdown-confluence-sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telefonica/markdown-confluence-sync",
   "description": "Creates/updates/deletes Confluence pages based on markdown files in a directory. Supports Mermaid diagrams and per-page configuration using frontmatter metadata. Works great with Docusaurus",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "Apache-2.0",
   "author": "Telefónica Innovación Digital",
   "repository": {

--- a/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.ts
@@ -36,6 +36,8 @@ import type {
   AuthenticationOption,
   RehypeCodeBlocksOptionDefinition,
   RehypeCodeBlocksOption,
+  RehypeGithubAlertsOptionDefinition,
+  RehypeGithubAlertsOption,
   ApiPrefixOption,
   ApiPrefixOptionDefinition,
 } from "./ConfluenceSync.types.js";
@@ -101,6 +103,12 @@ const rehypeCodeBlocksOption: RehypeCodeBlocksOptionDefinition = {
   default: false,
 };
 
+const rehypeGithubAlertsOption: RehypeGithubAlertsOptionDefinition = {
+  name: "githubAlerts",
+  type: "boolean",
+  default: false,
+};
+
 export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
   implements ConfluenceSyncInterface
 {
@@ -120,6 +128,7 @@ export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
   private _logger: LoggerInterface;
   private _modeOption: ModeOption;
   private _rehypeCodeBlocksOption: RehypeCodeBlocksOption;
+  private _rehypeGithubAlertsOption: RehypeGithubAlertsOption;
 
   constructor({ config, rehypeConfig, logger, mode }: ConfluenceSyncOptions) {
     this._urlOption = config.addOption(urlOption) as UrlOption;
@@ -150,6 +159,10 @@ export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
     this._rehypeCodeBlocksOption = rehypeConfig.addOption(
       rehypeCodeBlocksOption,
     ) as RehypeCodeBlocksOption;
+
+    this._rehypeGithubAlertsOption = rehypeConfig.addOption(
+      rehypeGithubAlertsOption,
+    ) as RehypeGithubAlertsOption;
 
     this._modeOption = mode;
     this._logger = logger;
@@ -220,6 +233,7 @@ export const ConfluenceSync: ConfluenceSyncConstructor = class ConfluenceSync
         logger: this._logger.namespace("transformer"),
         rehype: {
           codeBlocks: this._rehypeCodeBlocksOption.value,
+          githubAlerts: this._rehypeGithubAlertsOption.value,
         },
       });
 

--- a/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.types.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/ConfluenceSync.types.ts
@@ -25,6 +25,7 @@ type NoticeTemplateOptionValue = string;
 type DryRunOptionValue = boolean;
 
 type RehypeCodeBlocksOptionValue = boolean;
+type RehypeGithubAlertsOptionValue = boolean;
 
 declare global {
   //eslint-disable-next-line @typescript-eslint/no-namespace
@@ -58,6 +59,8 @@ declare global {
       rehype?: {
         /** Enable code blocks transformation to Confluence code macro */
         codeBlocks?: RehypeCodeBlocksOptionValue;
+        /** Enable GitHub alerts transformation to Confluence info/note/warning/tip macros */
+        githubAlerts?: RehypeGithubAlertsOptionValue;
       };
     }
   }
@@ -82,6 +85,8 @@ export type DryRunOptionDefinition = OptionDefinition<
 >;
 export type RehypeCodeBlocksOptionDefinition =
   OptionDefinition<RehypeCodeBlocksOptionValue>;
+export type RehypeGithubAlertsOptionDefinition =
+  OptionDefinition<RehypeGithubAlertsOptionValue>;
 
 export type AuthenticationOptionDefinition =
   OptionDefinition<ConfluenceClientAuthenticationConfig>;
@@ -106,6 +111,11 @@ export type DryRunOption = OptionInterfaceOfType<
 
 export type RehypeCodeBlocksOption = OptionInterfaceOfType<
   RehypeCodeBlocksOptionValue,
+  { hasDefault: true }
+>;
+
+export type RehypeGithubAlertsOption = OptionInterfaceOfType<
+  RehypeGithubAlertsOptionValue,
   { hasDefault: true }
 >;
 

--- a/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.ts
@@ -27,6 +27,7 @@ import { InvalidTemplateError } from "./errors/InvalidTemplateError.js";
 import rehypeAddAttachmentsImages from "./support/rehype/rehype-add-attachments-images.js";
 import type { ImagesMetadata } from "./support/rehype/rehype-add-attachments-images.types.js";
 import rehypeAddNotice from "./support/rehype/rehype-add-notice.js";
+import rehypeReplaceGithubAlerts from "./support/rehype/rehype-replace-github-alerts.js";
 import rehypeReplaceCodeBlocks from "./support/rehype/rehype-replace-code-blocks.js";
 import rehypeReplaceDetails from "./support/rehype/rehype-replace-details.js";
 import rehypeReplaceImgTags from "./support/rehype/rehype-replace-img-tags.js";
@@ -52,6 +53,7 @@ export const ConfluencePageTransformer: ConfluencePageTransformerConstructor = c
   private readonly _spaceKey: string;
   private readonly _logger?: LoggerInterface;
   private readonly _rehypeCodeBlocksEnabled: boolean;
+  private readonly _rehypeGithubAlertsEnabled: boolean;
 
   constructor({
     noticeMessage,
@@ -59,7 +61,7 @@ export const ConfluencePageTransformer: ConfluencePageTransformerConstructor = c
     rootPageName,
     spaceKey,
     logger,
-    rehype: { codeBlocks },
+    rehype: { codeBlocks, githubAlerts },
   }: ConfluencePageTransformerOptions) {
     this._noticeMessage = noticeMessage;
     this._noticeTemplateRaw = noticeTemplate;
@@ -70,9 +72,10 @@ export const ConfluencePageTransformer: ConfluencePageTransformerConstructor = c
     this._spaceKey = spaceKey;
     this._logger = logger;
     this._rehypeCodeBlocksEnabled = codeBlocks ?? false;
+    this._rehypeGithubAlertsEnabled = githubAlerts ?? false;
 
     logger?.debug(
-      `ConfluencePageTransformer initialized with rehype options: ${JSON.stringify({ codeBlocks: this._rehypeCodeBlocksEnabled })}`,
+      `ConfluencePageTransformer initialized with rehype options: ${JSON.stringify({ codeBlocks: this._rehypeCodeBlocksEnabled, alerts: this._rehypeGithubAlertsEnabled })}`,
     );
   }
 
@@ -115,6 +118,12 @@ export const ConfluencePageTransformer: ConfluencePageTransformerConstructor = c
       if (this._rehypeCodeBlocksEnabled) {
         this._logger?.debug(`Registering rehypeReplaceCodeBlocks plugin`);
         processor = processor.use(rehypeReplaceCodeBlocks);
+      }
+
+      // Conditionally add alerts plugin
+      if (this._rehypeGithubAlertsEnabled) {
+        this._logger?.debug(`Registering rehypeReplaceAlerts plugin`);
+        processor = processor.use(rehypeReplaceGithubAlerts);
       }
 
       const content = processor

--- a/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.types.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.types.ts
@@ -18,6 +18,14 @@ export interface ConfluencePageTransformerRehypeOptions {
    * @default false
    */
   codeBlocks?: boolean;
+  /**
+   * Enable GitHub alerts transformation to Confluence info/note/warning/tip macros.
+   * When enabled, GitHub-flavored markdown alerts (e.g., [!NOTE], [!WARNING])
+   * will be converted to appropriate Confluence macro format.
+   * When this option is not specified or set to false, alerts will remain as blockquotes.
+   * @default false
+   */
+  githubAlerts?: boolean;
 }
 
 export interface ConfluencePageTransformerOptions {

--- a/components/markdown-confluence-sync/src/lib/confluence/transformer/support/rehype/rehype-replace-github-alerts.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/transformer/support/rehype/rehype-replace-github-alerts.ts
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Element as HastElement, Root, Text as HastText } from "hast";
+import type { Plugin as UnifiedPlugin } from "unified";
+
+import { replace } from "../../../../support/unist/unist-util-replace.js";
+
+/**
+ * Alert type mapping for GitHub-flavored markdown alerts
+ */
+type GithubAlertType = "NOTE" | "TIP" | "IMPORTANT" | "WARNING" | "CAUTION";
+
+/**
+ * Confluence macro names for different alert types
+ */
+const ALERT_TO_MACRO: Record<GithubAlertType, string> = {
+  NOTE: "info",
+  TIP: "tip",
+  IMPORTANT: "note",
+  WARNING: "warning",
+  CAUTION: "warning",
+};
+
+/**
+ * Default titles for alert types
+ */
+const ALERT_TITLES: Record<GithubAlertType, string> = {
+  NOTE: "Note",
+  TIP: "Tip",
+  IMPORTANT: "Important",
+  WARNING: "Warning",
+  CAUTION: "Caution",
+};
+
+/**
+ * UnifiedPlugin to replace GitHub alert blockquotes with Confluence's
+ * structured info/note/warning/tip macro format.
+ *
+ * @see {@link https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts | GitHub Alerts }
+ * @see {@link https://developer.atlassian.com/server/confluence/confluence-storage-format/ | Confluence Storage Format }
+ *
+ * @example
+ *  <blockquote>
+ *    <p>[!NOTE]<br/>This is a note</p>
+ *  </blockquote>
+ *  // becomes
+ *  <ac:structured-macro ac:name="info">
+ *    <ac:parameter ac:name="title">Note</ac:parameter>
+ *    <ac:rich-text-body>
+ *      <p>This is a note</p>
+ *    </ac:rich-text-body>
+ *  </ac:structured-macro>
+ */
+const rehypeReplaceGithubAlerts: UnifiedPlugin<[], Root> =
+  function rehypeReplaceGithubAlerts() {
+    return function transformer(tree) {
+      replace(tree, { type: "element", tagName: "blockquote" }, (node) => {
+        // Check if this blockquote is a GitHub alert
+        const alertInfo = extractAlertInfo(node);
+
+        if (!alertInfo) {
+          // Not a GitHub alert, return unchanged
+          return node;
+        }
+
+        // Build the Confluence macro
+        const macroName = ALERT_TO_MACRO[alertInfo.type];
+        const macroChildren: HastElement[] = [];
+
+        // Add title parameter
+        macroChildren.push({
+          type: "element" as const,
+          tagName: "ac:parameter",
+          properties: {
+            "ac:name": "title",
+          },
+          children: [
+            {
+              type: "raw" as const,
+              value: ALERT_TITLES[alertInfo.type],
+            },
+          ],
+        });
+
+        // Add the content in a rich text body
+        macroChildren.push({
+          type: "element" as const,
+          tagName: "ac:rich-text-body",
+          properties: {},
+          children: alertInfo.content,
+        });
+
+        return {
+          type: "element" as const,
+          tagName: "ac:structured-macro",
+          properties: {
+            "ac:name": macroName,
+          },
+          children: macroChildren,
+        };
+      });
+    };
+  };
+
+/**
+ * Interface for alert information extracted from a blockquote
+ */
+interface AlertInfo {
+  type: GithubAlertType;
+  content: HastElement["children"];
+}
+
+/**
+ * Extract alert information from a blockquote element if it contains a
+ * GitHub alert marker.
+ *
+ * @param blockquote - The blockquote element to check
+ * @returns Alert information if this is a GitHub alert, undefined otherwise
+ */
+function extractAlertInfo(blockquote: HastElement): AlertInfo | undefined {
+  if (blockquote.children.length === 0) {
+    return undefined;
+  }
+
+  // Find the first non-whitespace child (skip whitespace text nodes)
+  let contentChild = blockquote.children[0];
+  let childIndex = 0;
+
+  while (
+    contentChild &&
+    contentChild.type === "text" &&
+    !(contentChild as HastText).value.trim()
+  ) {
+    childIndex++;
+    if (childIndex >= blockquote.children.length) {
+      // istanbul ignore next - Defensive check, should not happen
+      return undefined;
+    }
+    contentChild = blockquote.children[childIndex];
+  }
+
+  // Handle two cases: text node directly or paragraph element
+  let textNode: HastText | undefined;
+  let isDirectText = false;
+
+  if (contentChild.type === "text") {
+    // Direct text node with actual content
+    textNode = contentChild as HastText;
+    isDirectText = true;
+  } else if (contentChild.type === "element" && contentChild.tagName === "p") {
+    // Paragraph element
+    const paragraph = contentChild as HastElement;
+    const firstNode = paragraph.children[0];
+    if (firstNode && firstNode.type === "text") {
+      textNode = firstNode as HastText;
+    }
+  }
+
+  if (!textNode) {
+    // istanbul ignore next - Defensive check, should not happen
+    return undefined;
+  }
+
+  const text = textNode.value;
+
+  // Check if it starts with an alert marker
+  const alertMatch = text.match(/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/);
+  if (!alertMatch) {
+    return undefined;
+  }
+
+  const alertType = alertMatch[1] as GithubAlertType;
+
+  // Remove the alert marker from the text
+  const remainingText = text.substring(alertMatch[0].length).trim();
+
+  // Build content based on structure
+  const content: HastElement["children"] = [];
+
+  if (isDirectText) {
+    // For direct text, wrap remaining content in a paragraph
+    if (remainingText) {
+      content.push({
+        type: "element",
+        tagName: "p",
+        properties: {},
+        children: [
+          {
+            type: "text",
+            value: remainingText,
+          } as HastText,
+        ],
+      } as HastElement);
+    }
+    // Add any other children from the blockquote (after the text node we used)
+    content.push(...blockquote.children.slice(childIndex + 1));
+  } else {
+    // For paragraph structure
+    const paragraph = contentChild as HastElement;
+    const newParagraphChildren = [...paragraph.children];
+
+    if (remainingText) {
+      newParagraphChildren[0] = {
+        type: "text",
+        value: remainingText,
+      } as HastText;
+    } else {
+      newParagraphChildren.shift();
+    }
+
+    if (newParagraphChildren.length > 0) {
+      content.push({
+        ...paragraph,
+        children: newParagraphChildren,
+      });
+    }
+
+    // Add any other children from the blockquote (after the paragraph we used)
+    content.push(...blockquote.children.slice(childIndex + 1));
+  }
+
+  return {
+    type: alertType,
+    content,
+  };
+}
+
+export default rehypeReplaceGithubAlerts;

--- a/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/support/rehype/rehype-replace-github-alerts.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/support/rehype/rehype-replace-github-alerts.test.ts
@@ -1,0 +1,504 @@
+// SPDX-FileCopyrightText: 2025 Telefónica Innovación Digital
+// SPDX-License-Identifier: Apache-2.0
+
+import rehypeParse from "rehype-parse";
+import rehypeRaw from "rehype-raw";
+import rehypeStringify from "rehype-stringify";
+import { unified } from "unified";
+
+import rehypeReplaceAlerts from "@src/lib/confluence/transformer/support/rehype/rehype-replace-github-alerts";
+
+describe("rehype-replace-github-alerts", () => {
+  it("should be defined", () => {
+    expect(rehypeReplaceAlerts).toBeDefined();
+  });
+
+  it("should replace [!NOTE] alert to Confluence info macro", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!NOTE]
+This is a note</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain('<ac:parameter ac:name="title">Note');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).toContain("This is a note");
+  });
+
+  it("should replace [!TIP] alert to Confluence tip macro", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!TIP]
+This is a helpful tip</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="tip">');
+    expect(result).toContain('<ac:parameter ac:name="title">Tip');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).toContain("This is a helpful tip");
+  });
+
+  it("should replace [!IMPORTANT] alert to Confluence note macro", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!IMPORTANT]
+This is important information</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="note">');
+    expect(result).toContain('<ac:parameter ac:name="title">Important');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).toContain("This is important information");
+  });
+
+  it("should replace [!WARNING] alert to Confluence warning macro", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!WARNING]
+This is a warning</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="warning">');
+    expect(result).toContain('<ac:parameter ac:name="title">Warning');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).toContain("This is a warning");
+  });
+
+  it("should replace [!CAUTION] alert to Confluence warning macro", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!CAUTION]
+This is a caution</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="warning">');
+    expect(result).toContain('<ac:parameter ac:name="title">Caution');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).toContain("This is a caution");
+  });
+
+  it("should handle alert with multiple paragraphs", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!NOTE]
+First paragraph</p>
+<p>Second paragraph</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("First paragraph");
+    expect(result).toContain("Second paragraph");
+  });
+
+  it("should not transform regular blockquotes", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>This is a regular blockquote</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("<blockquote>");
+    expect(result).toContain("This is a regular blockquote");
+  });
+
+  it("should not transform blockquote without paragraph", () => {
+    // Arrange
+    const html = `<blockquote>
+Just text
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("<blockquote>");
+  });
+
+  it("should handle alert with only marker (no additional text)", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!NOTE]</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain('<ac:parameter ac:name="title">Note');
+  });
+
+  it("should handle alert with formatted content", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!NOTE]
+This has <strong>bold</strong> and <em>italic</em> text</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("<strong>bold</strong>");
+    expect(result).toContain("<em>italic</em>");
+  });
+
+  it("should handle alert with code in content", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!TIP]
+Use <code>npm install</code> to install packages</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="tip">');
+    expect(result).toContain("<code>npm install</code>");
+  });
+
+  it("should handle alert with list in content", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!WARNING]
+Important steps:</p>
+<ul>
+<li>Step 1</li>
+<li>Step 2</li>
+</ul>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="warning">');
+    expect(result).toContain("Important steps:");
+    expect(result).toContain("<ul>");
+    expect(result).toContain("Step 1");
+    expect(result).toContain("Step 2");
+  });
+
+  it("should not transform blockquote with alert marker not at start", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>This is not an alert [!NOTE]</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("<blockquote>");
+  });
+
+  it("should handle empty blockquote", () => {
+    // Arrange
+    const html = `<blockquote></blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="info">');
+  });
+
+  it("should handle multiple different alerts", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!NOTE]
+First note</p>
+</blockquote>
+<blockquote>
+<p>[!WARNING]
+Then a warning</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain('<ac:structured-macro ac:name="warning">');
+    expect(result).toContain("First note");
+    expect(result).toContain("Then a warning");
+  });
+
+  it("should not transform other elements", () => {
+    // Arrange
+    const html = `<p>paragraph</p><div>division</div>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).not.toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("<p>paragraph</p>");
+    expect(result).toContain("<div>division</div>");
+  });
+
+  it("should handle alert with text immediately after marker", () => {
+    // Arrange
+    const html = `<blockquote>
+<p>[!NOTE]Immediate text</p>
+</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain("Immediate text");
+  });
+
+  it("should handle direct text node with remaining text after alert marker", () => {
+    // Arrange
+    const html = `<blockquote>[!WARNING] Direct text with remaining content</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="warning">');
+    expect(result).toContain('<ac:parameter ac:name="title">Warning');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).toContain("<p>Direct text with remaining content</p>");
+  });
+
+  it("should handle direct text node without remaining text after alert marker", () => {
+    // Arrange
+    const html = `<blockquote>[!TIP]</blockquote>`;
+
+    // Act
+    const result = unified()
+      .use(rehypeParse)
+      .use(rehypeRaw)
+      .use(rehypeReplaceAlerts)
+      .use(rehypeStringify, {
+        allowDangerousHtml: true,
+        closeSelfClosing: true,
+        tightSelfClosing: true,
+      })
+      .processSync(html)
+      .toString();
+
+    // Assert
+    expect(result).toContain('<ac:structured-macro ac:name="tip">');
+    expect(result).toContain('<ac:parameter ac:name="title">Tip');
+    expect(result).toContain("<ac:rich-text-body>");
+    expect(result).not.toContain("<p></p>");
+  });
+});


### PR DESCRIPTION
# markdown-confluence-sync v2.4.0

## Description

### markdown-confluence-sync

#### Added

* feat(#70): Add GitHub alerts transformation to Confluence macros.
  GitHub-flavored markdown alerts ([!NOTE], [!TIP], [!IMPORTANT],
  [!WARNING], [!CAUTION]) are now converted to Confluence's native
  info, note, warning, and tip macros. This feature is disabled by
  default and can be enabled via `rehype.alerts` configuration option.

closes #70 

## Agreement

Please check the following boxes after you have read and understood each item.

* [ ] I have read the [CONTRIBUTING](https://github.com/Telefonica/confluence-tools/blob/main/.github/CONTRIBUTING.md) document
* [ ] I have read the [CODE_OF_CONDUCT](https://github.com/Telefonica/confluence-tools/blob/main/.github/CODE_OF_CONDUCT.md) document
* [ ] I accept that, by signing the Contributor License Agreement through a comment in the PR, my Github user name will be stored by in a branch of this repository for future reference.

In case this is your first contribution to this project, you will also have to **add a comment with the following text: "_I have read the CLA Document and I hereby sign the CLA_"**, otherwise the PR status will fail and our bot will request you to add it. Once you have signed it in a PR, you will not have to sign it again for future contributions.
