### PR TITLE
fix: Remove deprecated hast@1.0.0 package dependency

### DIFF
--- a/components/markdown-confluence-sync/CHANGELOG.md
+++ b/components/markdown-confluence-sync/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Deprecated
 #### Removed
 
+* fix: Remove deprecated `hast@1.0.0` package dependency. The package
+  was renamed and is no longer needed as `@types/hast` already provides
+  all necessary type definitions. This eliminates the npm deprecation
+  warning in downstream projects.
+
 ## [2.4.0] - 2025-11-27
 
 #### Added

--- a/components/markdown-confluence-sync/package.json
+++ b/components/markdown-confluence-sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telefonica/markdown-confluence-sync",
   "description": "Creates/updates/deletes Confluence pages based on markdown files in a directory. Supports Mermaid diagrams and per-page configuration using frontmatter metadata. Works great with Docusaurus",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "Apache-2.0",
   "author": "Telefónica Innovación Digital",
   "repository": {
@@ -79,7 +79,6 @@
     "glob": "10.3.10",
     "globule": "1.3.4",
     "handlebars": "4.7.8",
-    "hast": "1.0.0",
     "hast-util-to-string": "2.0.0",
     "mdast-util-mdx": "3.0.0",
     "mdast-util-mdx-jsx": "3.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ importers:
       handlebars:
         specifier: 4.7.8
         version: 4.7.8
-      hast:
-        specifier: 1.0.0
-        version: 1.0.0
       hast-util-to-string:
         specifier: 2.0.0
         version: 2.0.0
@@ -3552,10 +3549,6 @@ packages:
   hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
 
-  hast@1.0.0:
-    resolution: {integrity: sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==}
-    deprecated: Renamed to rehype
-
   hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
 
@@ -5101,6 +5094,7 @@ packages:
   puppeteer@23.11.1:
     resolution: {integrity: sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==}
     engines: {node: '>=18'}
+    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:
@@ -10125,8 +10119,6 @@ snapshots:
       '@types/hast': 2.3.10
 
   hast-util-whitespace@2.0.1: {}
-
-  hast@1.0.0: {}
 
   hastscript@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Removes the deprecated `hast@1.0.0` package from markdown-confluence-sync dependencies to eliminate npm deprecation warnings in downstream projects.

## Changes

- Remove `hast@1.0.0` from dependencies in package.json
- Update CHANGELOG.md with fix entry under "Removed" section
- Bump package version from 2.4.0 to 2.4.1 (PATCH)
- Update pnpm-lock.yaml

## Background

The `hast` package was deprecated and renamed. The package wasn't actually imported anywhere in the codebase, and `@types/hast@2.3.10` already provides all necessary type definitions.

## Verification

- ✅ TypeScript type checking passes (`npx tsc --noEmit`)
- ✅ Linting passes (`npx eslint .`)
- ✅ No other components in the monorepo are affected
- ✅ All hast-related utilities (like `hast-util-to-string`) continue to work
- ✅ No deprecation warning when running `pnpm install`

## Impact

This change is completely isolated to the `markdown-confluence-sync` package and has no impact on other components in the monorepo.