### PR TITLE
Remove hierarchy prefixes from tree mode titles

### DIFF
--- a/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.ts
+++ b/components/markdown-confluence-sync/src/lib/confluence/transformer/ConfluencePageTransformer.ts
@@ -202,21 +202,9 @@ export const ConfluencePageTransformer: ConfluencePageTransformerConstructor = c
   private _transformPageTitles(
     pages: ConfluenceSyncPage[],
   ): ConfluenceSyncPage[] {
-    const pagesMap = new Map(pages.map((page) => [page.path, page]));
-    const rootPageAncestor =
-      this._rootPageName !== undefined ? [this._rootPageName] : [];
     const pageTitleLookupTable = new Map(
       pages.map((page) => {
-        const ancestors = this._resolveAncestorsTitles(page, pagesMap);
-        const ancestorsTitle = rootPageAncestor
-          .concat(ancestors)
-          .map((ancestor) => `[${ancestor}]`)
-          .join("");
-        const title =
-          ancestorsTitle !== ""
-            ? `${ancestorsTitle} ${page.title}`
-            : page.title;
-        return [page.path, title];
+        return [page.path, page.title];
       }),
     );
     this._logger?.debug(
@@ -231,18 +219,4 @@ export const ConfluencePageTransformer: ConfluencePageTransformerConstructor = c
     }));
   }
 
-  private _resolveAncestorsTitles(
-    page: ConfluenceSyncPage,
-    pages: Map<string, ConfluenceSyncPage>,
-  ): string[] {
-    return page.ancestors.map((ancestor) => {
-      const ancestorPage = pages.get(ancestor);
-      // NOTE: Coverage ignored because it is unreachable from tests. Defensive programming.
-      // istanbul ignore next
-      if (!ancestorPage) {
-        throw new Error(`Ancestor page not found: ${ancestor}`);
-      }
-      return ancestorPage.name ?? ancestorPage.title;
-    });
-  }
 };

--- a/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/ConfluencePageTransformer.test.ts
+++ b/components/markdown-confluence-sync/test/unit/specs/confluence/transformer/ConfluencePageTransformer.test.ts
@@ -250,14 +250,14 @@ describe("confluencePageTransformer", () => {
           attachments: {},
         },
         {
-          title: "[Parent 1] Page 1",
+          title: "Page 1",
           ancestors: ["Parent 1"],
           content: expect.stringContaining("<p>Page 1 content</p>"),
           attachments: {},
         },
         {
-          title: "[Parent 1][Page 1] Child 1",
-          ancestors: ["Parent 1", "[Parent 1] Page 1"],
+          title: "Child 1",
+          ancestors: ["Parent 1", "Page 1"],
           content: expect.stringContaining("<p>Child 1 content</p>"),
           attachments: {},
         },
@@ -307,14 +307,14 @@ describe("confluencePageTransformer", () => {
           attachments: {},
         },
         {
-          title: "[Root] Title Page 1",
+          title: "Title Page 1",
           ancestors: ["Parent 1"],
           content: expect.stringContaining("<p>Page 1 content</p>"),
           attachments: {},
         },
         {
-          title: "[Root][Page 1] Child 1",
-          ancestors: ["Parent 1", "[Root] Title Page 1"],
+          title: "Child 1",
+          ancestors: ["Parent 1", "Title Page 1"],
           content: expect.stringContaining("<p>Child 1 content</p>"),
           attachments: {},
         },
@@ -352,14 +352,14 @@ describe("confluencePageTransformer", () => {
     // Assert
     expect(transformedPages).toEqual([
       {
-        title: "[Root] Page 1",
+        title: "Page 1",
         ancestors: [],
         content: expect.stringContaining("<p>Page 1 content</p>"),
         attachments: {},
       },
       {
-        title: "[Root][Page 1] Child 1",
-        ancestors: ["[Root] Page 1"],
+        title: "Child 1",
+        ancestors: ["Page 1"],
         content: expect.stringContaining("<p>Child 1 content</p>"),
         attachments: {},
       },


### PR DESCRIPTION
Page titles no longer include ancestor prefixes like [Parent1][Parent2] since the folder structure already reflects the hierarchy. This simplifies page titles while still preserving the parent-child relationships through the ancestors array.